### PR TITLE
enable install on macos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ klujax_cpp = Extension(
         f"{site_packages}",
         suitesparse_lib,
     ],
-    extra_compile_args=[],
-    extra_link_args=["-static-libgcc", "-static-libstdc++"],
+    extra_compile_args=["-std=c++11"] if sys.platform=="darwin" else [],
+    extra_link_args= [] if sys.platform=="darwin" else ["-static-libgcc", "-static-libstdc++"],
     libraries=[
         "klu",
         "btf",


### PR DESCRIPTION
clang does not support `-static-libgcc` and `-static-libstdc++`
additionally C++11 features need to be enabled