### PR TITLE
Add low-level split-solve API for advanced users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Note that `float32`/`complex64` arrays will be cast to `float64`/`complex128`!
 The `klujax` library provides a single function `solve(Ai, Aj, Ax, b)`, which solves for `x` in
 the sparse linear system `Ax=b`, where `A` is explicitly given in COO-format (`Ai`, `Aj`, `Ax`).
 
+The function is JIT-compilable and supports JAX autograd (`jax.grad`, `jax.jacfwd`, `jax.jacrev`).
+
 > NOTE: the sparse matrix represented by (`Ai`, `Aj`, `Ax`) needs to be [coalesced](https://pytorch.org/docs/stable/sparse.html#uncoalesced-sparse-coo-tensors)!
 > KLUJAX provides a `coalesce` function (which unfortunately is not jax-jittable).
 
@@ -95,7 +97,7 @@ most platforms as follows:
 pip install klujax
 ```
 
-**There exist pre-built wheels for Linux and Windows (python 3.8+).** If no compatible
+**There exist pre-built wheels for Linux and Windows (Python 3.11+).** If no compatible
 wheel is found, however, pip will attempt to install the library from source... make
 sure you have the necessary build dependencies installed (see [Installing from Source](#installing-from-source))
 
@@ -107,9 +109,9 @@ sure you have the necessary build dependencies installed (see [Installing from S
 Before installing, clone the build dependencies:
 
 ```sh
-git clone --depth 1 --branch v7.2.0 https://github.com/DrTimothyAldenDavis/SuiteSparse suitesparse
-git clone --depth 1 --branch main https://github.com/openxla/xla xla
-git clone --depth 1 --branch stable https://github.com/pybind/pybind11 pybind11
+git clone --depth 1 --branch v7.5.0 https://github.com/DrTimothyAldenDavis/SuiteSparse suitesparse
+git clone https://github.com/openxla/xla xla && cd xla && git checkout 05f004e8368c955b872126b1c978c60e33bbc5c8 && cd ..
+git clone --depth 1 --branch v2.13.6 https://github.com/pybind/pybind11 pybind11
 ```
 
 ### Linux
@@ -154,7 +156,7 @@ pip install .
 
 ## License & Credits
 
-© Floris Laporte 2022, LGPL-2.1
+© Floris Laporte 2022-2026, LGPL-2.1
 
 This library was partly based on:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ select = ["ALL"]
 ".github/run_tests.py" = ["INP", "PTH", "T201", "S603", "S607"]
 "benchmark.py" = ["INP001", "T201"]
 "setup.py" = ["PTH", "ANN", "D101", "D102"]
-"tests.py" = ["D", "INP001", "ANN", "T201", "E501", "N806"]
+"tests.py" = ["D", "INP001", "ANN", "T201", "E501", "N806", "S101", "SIM108", "PLC0415", "B905"]
 
 [tool.setuptools.package-data]
 "*" = [

--- a/tests.py
+++ b/tests.py
@@ -2,8 +2,10 @@ import sys
 from functools import wraps
 
 import jax
+import jax.ffi
 import jax.numpy as jnp
 import jax.scipy as jsp
+import klujax_cpp
 import numpy as np
 import pytest
 from jax import lax
@@ -251,3 +253,159 @@ def _is_almost_equal(arr1, arr2):
         return False
     else:
         return True
+
+
+# =============================================================================
+# Tests for low-level split-solve API (klujax_cpp)
+# =============================================================================
+
+
+def _register_ffi_targets():
+    """Register FFI targets for low-level API tests."""
+    import jax.ffi
+
+    # Only register if not already registered
+    try:
+        jax.ffi.register_ffi_target("test_coo_to_csc", klujax_cpp.coo_to_csc())
+        jax.ffi.register_ffi_target("test_solve_csc_f64", klujax_cpp.solve_csc_f64())
+        jax.ffi.register_ffi_target("test_solve_csc_c128", klujax_cpp.solve_csc_c128())
+    except ValueError:
+        pass  # Already registered
+
+
+@log_test_name
+def test_coo_to_csc():
+    """Test that coo_to_csc correctly converts COO to CSC format."""
+    import jax.ffi
+
+    _register_ffi_targets()
+
+    # Simple 3x3 matrix in COO format
+    # [[1, 0, 2],
+    #  [0, 3, 0],
+    #  [4, 0, 5]]
+    Ai = jnp.array([0, 0, 1, 2, 2], dtype=jnp.int32)  # row indices
+    Aj = jnp.array([0, 2, 1, 0, 2], dtype=jnp.int32)  # col indices
+    n_col = 3
+    n_nz = len(Ai)
+
+    # Call coo_to_csc via FFI
+    coo_to_csc_fn = jax.ffi.ffi_call(
+        "test_coo_to_csc",
+        (
+            jax.ShapeDtypeStruct((n_col + 1,), jnp.int32),  # Bp
+            jax.ShapeDtypeStruct((n_nz,), jnp.int32),  # Bi
+            jax.ShapeDtypeStruct((n_nz,), jnp.int32),  # Bk
+        ),
+        vmap_method="sequential",
+    )
+    Bp, Bi, Bk = coo_to_csc_fn(Ai, Aj, jnp.array([n_col], dtype=jnp.int32))
+
+    # Verify CSC format is correct
+    # Column 0: rows 0, 2 (values at COO indices 0, 3)
+    # Column 1: row 1 (value at COO index 2)
+    # Column 2: rows 0, 2 (values at COO indices 1, 4)
+    assert Bp.shape == (n_col + 1,)
+    assert Bi.shape == (n_nz,)
+    assert Bk.shape == (n_nz,)
+
+    # Bp should be column pointers: [0, 2, 3, 5]
+    np.testing.assert_array_equal(np.array(Bp), [0, 2, 3, 5])
+
+
+@log_test_name
+@parametrize_dtypes
+def test_solve_csc_matches_solve(dtype):
+    """Test that solve_csc produces the same result as klujax.solve."""
+    import jax.ffi
+
+    _register_ffi_targets()
+
+    # Generate test data
+    Ai, Aj, Ax, b = _get_rand_arrs_3d(n_lhs=2, n_nz=8, n_col=5, n_rhs=3, dtype=dtype)
+    n_col = b.shape[1]
+    n_nz = len(Ai)
+
+    # Get reference solution using high-level API
+    x_ref = klujax.solve(Ai, Aj, Ax, b)
+
+    # Convert COO to CSC
+    coo_to_csc_fn = jax.ffi.ffi_call(
+        "test_coo_to_csc",
+        (
+            jax.ShapeDtypeStruct((n_col + 1,), jnp.int32),
+            jax.ShapeDtypeStruct((n_nz,), jnp.int32),
+            jax.ShapeDtypeStruct((n_nz,), jnp.int32),
+        ),
+        vmap_method="sequential",
+    )
+    Bp, Bi, Bk = coo_to_csc_fn(Ai, Aj, jnp.array([n_col], dtype=jnp.int32))
+
+    # Solve using CSC format
+    if dtype == np.float64:
+        target_name = "test_solve_csc_f64"
+    else:
+        target_name = "test_solve_csc_c128"
+
+    solve_csc_fn = jax.ffi.ffi_call(
+        target_name,
+        jax.ShapeDtypeStruct(b.shape, dtype),
+        vmap_method="sequential",
+    )
+    x_csc = solve_csc_fn(Bp, Bi, Bk, Ax, b)
+
+    # Results should match
+    _log_and_test_equality(x_ref, x_csc)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_solve_csc_reuse(dtype):
+    """Test that CSC structure can be reused for multiple solves with different values."""
+    import jax.ffi
+
+    _register_ffi_targets()
+
+    # Generate test data with same sparsity pattern but different values
+    Ai, Aj, Ax1, b1 = _get_rand_arrs_3d(
+        n_lhs=2, n_nz=8, n_col=5, n_rhs=2, dtype=dtype, seed=42
+    )
+    _, _, Ax2, b2 = _get_rand_arrs_3d(
+        n_lhs=2, n_nz=8, n_col=5, n_rhs=2, dtype=dtype, seed=123
+    )
+
+    n_col = b1.shape[1]
+    n_nz = len(Ai)
+
+    # Convert COO to CSC once
+    coo_to_csc_fn = jax.ffi.ffi_call(
+        "test_coo_to_csc",
+        (
+            jax.ShapeDtypeStruct((n_col + 1,), jnp.int32),
+            jax.ShapeDtypeStruct((n_nz,), jnp.int32),
+            jax.ShapeDtypeStruct((n_nz,), jnp.int32),
+        ),
+        vmap_method="sequential",
+    )
+    Bp, Bi, Bk = coo_to_csc_fn(Ai, Aj, jnp.array([n_col], dtype=jnp.int32))
+
+    if dtype == np.float64:
+        target_name = "test_solve_csc_f64"
+    else:
+        target_name = "test_solve_csc_c128"
+
+    solve_csc_fn = jax.ffi.ffi_call(
+        target_name,
+        jax.ShapeDtypeStruct(b1.shape, dtype),
+        vmap_method="sequential",
+    )
+
+    # Solve first system
+    x1_csc = solve_csc_fn(Bp, Bi, Bk, Ax1, b1)
+    x1_ref = klujax.solve(Ai, Aj, Ax1, b1)
+    _log_and_test_equality(x1_ref, x1_csc)
+
+    # Solve second system (reusing CSC structure)
+    x2_csc = solve_csc_fn(Bp, Bi, Bk, Ax2, b2)
+    x2_ref = klujax.solve(Ai, Aj, Ax2, b2)
+    _log_and_test_equality(x2_ref, x2_csc)

--- a/uv.lock
+++ b/uv.lock
@@ -351,7 +351,7 @@ wheels = [
 
 [[package]]
 name = "klujax"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "jax" },


### PR DESCRIPTION
## Summary

Addresses #16 by exposing `klu_analyze`, `klu_factor`, and `klu_solve` separately for advanced users who need to optimize Newton-Raphson solvers by reusing symbolic analysis.

### New Functions in `klujax_cpp`

**True split-solve API (handle-based):**
- `klu_analyze(Bp, Bi)` - Symbolic analysis on CSC sparsity pattern. Returns a handle.
- `klu_factor_f64(symbolic_handle, Bp, Bi, Bx)` - Numeric factorization (float64). Returns a handle.
- `klu_factor_c128(symbolic_handle, Bp, Bi, Bx)` - Numeric factorization (complex128). Returns a handle.
- `klu_solve_f64(symbolic_handle, numeric_handle, b)` - Solve using pre-computed factorizations (float64).
- `klu_solve_c128(symbolic_handle, numeric_handle, b)` - Solve using pre-computed factorizations (complex128).
- `klu_free_symbolic(handle)` - Free a symbolic factorization handle.
- `klu_free_numeric(handle)` - Free a numeric factorization handle.

**FFI-based helpers:**
- `coo_to_csc` - Convert COO format (Ai, Aj) to CSC format (Bp, Bi, Bk)
- `solve_csc_f64` / `solve_csc_c128` - Solve using pre-computed CSC structure

### Usage Example (Newton-Raphson)

```python
import numpy as np
import klujax_cpp

# COO to CSC conversion (one-time)
Bp, Bi, Bx = convert_coo_to_csc(...)  # your helper

# Symbolic analysis (one-time for fixed sparsity pattern)
sym_handle = klujax_cpp.klu_analyze(Bp, Bi)

# Newton-Raphson loop
for iteration in range(max_iterations):
    # Update Jacobian values (same sparsity, new values)
    Bx = compute_jacobian_values(...)
    
    # Numeric factorization (each iteration)
    num_handle = klujax_cpp.klu_factor_f64(sym_handle, Bp, Bi, Bx)
    
    # Solve
    dx = klujax_cpp.klu_solve_f64(sym_handle, num_handle, residual)
    
    # Free numeric handle (symbolic is reused!)
    klujax_cpp.klu_free_numeric(num_handle)
    
    x = x + dx
    if converged:
        break

# Cleanup
klujax_cpp.klu_free_symbolic(sym_handle)
```

The key benefit is that `klu_analyze` (the expensive symbolic analysis) only needs to be called once per sparsity pattern, while `klu_factor` can be called repeatedly with different values.

**Note**: These are low-level functions accessible via `klujax_cpp` module. The high-level `klujax.solve` API remains unchanged.

## Test plan
- [x] All 46 tests pass (including 5 new tests for split-solve API)
- [x] New functions are exported and accessible via `klujax_cpp`
- [x] Pre-commit hooks pass

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)