### PR TITLE
Cd/issue 16 split solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ for t in range(steps):
 
 ### Fine-Grained Control (Numeric Factorization)
 
-If you need to solve the same system with many different $b$ vectors while the matrix $A$ remains constant, you can further split the numeric factorization. This is often performed in a modified Newton-Raphson loop where the computationally expensive jacobian+ factorization is only evaluated once and the **solve** stage is deemed "cheap" in comparison
+If you need to solve the same system with many different $b$ vectors while the matrix $A$ remains constant, you can further split the numeric factorization. This is often performed in a modified Newton-Raphson loop where the computationally expensive jacobian+factorization is only evaluated once and the **solve** stage is deemed "cheap" in comparison
 
 
 ```python
@@ -137,12 +137,12 @@ for i in range(100):
 ```
 
 ### Lifecycle & Pointer Pitfalls
-Because klujax manages raw C++ pointers, there are strict rules for avoiding memory leaks and segmentation faults.
+Because `klujax.analyze` and `klujax.factor` generate `KLUHandleManager` objects which wrap low level C++ pointers, there are strict rules for avoiding memory leaks and segmentation faults.
 
 #### The "Ghost Pointer" Problem inside JIT:
-JAX's jit works by "tracing" your code. During tracing, Python objects like the `KLUHandleManager` are converted into symbolic Tracers.
+JAX's jit works by tracing your code. During tracing, Python objects like the `KLUHandleManager` are converted into symbolic Tracers.
 
-* Outside JIT: The `KLUHandleManager` uses RAII. When the Python variable is deleted or goes out of scope, the C++ memory is freed automatically.
+* Outside JIT: The `KLUHandleManager` uses RAII (Resource Acquisition Is Initialization). When the Python variable is deleted or goes out of scope, the C++ memory is freed automatically.
 
 * Inside JIT: If you create a handle (via `analyze` or `factor`) **inside** a JIT-compiled function, the Python manager is "lost" during the conversion to XLA. XLA will allocate the C++ memory at runtime, but it will **never** call the free function.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ arrays with double precision**, i.e. float64 or complex128.
 
 Note that `float32`/`complex64` arrays will be cast to `float64`/`complex128`!
 
-## Usage
+## Basic Usage
 
-The `klujax` library provides a single function `solve(Ai, Aj, Ax, b)`, which solves for `x` in
+The `klujax` library provides a basic function `solve(Ai, Aj, Ax, b)`, which solves for `x` in
 the sparse linear system `Ax=b`, where `A` is explicitly given in COO-format (`Ai`, `Aj`, `Ax`).
 
 > NOTE: the sparse matrix represented by (`Ai`, `Aj`, `Ax`) needs to be [coalesced](https://pytorch.org/docs/stable/sparse.html#uncoalesced-sparse-coo-tensors)!
@@ -85,6 +85,92 @@ Output:
 [ True True True True True]
 [1. 2. 3. 4. 5.]
 ```
+
+## Advanced Usage
+
+For high-performance applications like transient simulations or iterative solvers, you should avoid using the high-level `klujax.solve` function. The `klujax.solve` is in fact a wrapper around three distinct parts of the KLU algorithm:
+
+1) **Analyze (Symbolic)**: Inspects the sparsity pattern ($A_i, A_j$) to find optimal permutations and block triangular forms. This depends only on the structure of the matrix.
+2) **Factorize (Numeric)**: Performs the actual LU decomposition. This depends on the values ($A_x$) and requires a symbolic handle.
+3) **Solve (Numeric)**: Executes forward and backward substitution to find $x$. This depends on the right-hand side ($b$) and requires a numeric handle.
+
+Significant performance gains are achieved by hoisting the "Analysis" or "Factorization" steps out of your inner loops.
+
+### 1. High-Performance Transient Pattern (Reusing Symbolic)
+In a simulation where the sparsity pattern is constant but the values ($A_x$) and right-hand side ($b$) change, you should perform the expensive `analyze` step exactly once outside your JIT loop.
+
+```python
+import jax
+import klujax
+
+# 1. Analyze once in Python (CPU)
+# Returns a KLUHandleManager that automatically cleans up C++ memory
+symbolic = klujax.analyze(Ai, Aj, n_col)
+
+@jax.jit
+def simulation_step(Ax_t, b_t, sym):
+    # 2. Use the symbolic handle inside JIT
+    # The solver will perform numeric factorization and solve
+    return klujax.solve_with_symbol(Ai, Aj, Ax_t, b_t, sym)
+
+for t in range(steps):
+    x_t = simulation_step(Ax[t], b[t], symbolic)
+
+```
+
+### Fine-Grained Control (Numeric Factorization)
+
+If you need to solve the same system with many different $b$ vectors while the matrix $A$ remains constant, you can further split the numeric factorization. This is often performed in a modified Newton-Raphson loop where the computationally expensive jacobian+ factorization is only evaluated once and the **solve** stage is deemed "cheap" in comparison
+
+
+```python
+# Factorize the matrix once
+numeric = klujax.factor(Ai, Aj, Ax, symbolic)
+
+@jax.jit
+def fast_solve(b_t, num, sym):
+    # This call is extremely fast as it skips factorization entirely
+    return klujax.solve_with_numeric(num, b_t, sym)
+
+for i in range(100):
+    x_i = fast_solve(b_batch[i], numeric, symbolic)
+```
+
+### Lifecycle & Pointer Pitfalls
+Because klujax manages raw C++ pointers, there are strict rules for avoiding memory leaks and segmentation faults.
+
+#### The "Ghost Pointer" Problem inside JIT:
+JAX's jit works by "tracing" your code. During tracing, Python objects like the `KLUHandleManager` are converted into symbolic Tracers.
+
+* Outside JIT: The `KLUHandleManager` uses RAII. When the Python variable is deleted or goes out of scope, the C++ memory is freed automatically.
+
+* Inside JIT: If you create a handle (via `analyze` or `factor`) **inside** a JIT-compiled function, the Python manager is "lost" during the conversion to XLA. XLA will allocate the C++ memory at runtime, but it will **never** call the free function.
+
+#### The Fix: Explicit Destruction with Dependencies
+If you must create a handle inside JIT, you must manually call `free_symbolic` or `free_numeric` inside that same function. To prevent the compiler from freeing the pointer before the solve is finished, you must pass the solution as a dependency.
+
+```python
+@jax.jit
+def dynamic_solve(Ai, Aj, Ax, b):
+    # 1. Born inside JIT (No automatic cleanup!)
+    sym = klujax.analyze(Ai, Aj, 5)
+    
+    # 2. Compute solution
+    x = klujax.solve_with_symbol(Ai, Aj, Ax, b, sym)
+    
+    # 3. CRITICAL: Force XLA to free 'sym' ONLY AFTER 'x' is ready
+    klujax.free_symbolic(sym, dependency=x)
+    
+    return x
+```
+
+#### Summary of Best Practices
+1) **Hoist Creations**: Always try to call analyze or factor outside of JIT blocks.
+
+2) **One Manager, One Free**: Do not manually call free_symbolic(manager) and then let the manager go out of scope; it will attempt a double-free (though the library has safeguards to prevent a crash).
+
+3) **Check for Warnings**: If you see a UserWarning: Allocating KLU handle inside JIT, your code is currently leaking memory. Use the dependency pattern shown above to fix it.
+
 
 ## Installation
 

--- a/klujax.cpp
+++ b/klujax.cpp
@@ -3,6 +3,7 @@
 
 #include <cmath>
 
+#include <complex>
 #include "klu.h"
 #include "pybind11/pybind11.h"
 #include "xla/ffi/api/ffi.h"
@@ -12,7 +13,7 @@ namespace ffi = xla::ffi;
 #include <cstring>  // for memset
 #include <memory>   // for unique_ptr
 
-ffi::Error validate_dot_f64_args(
+ffi::Error validate_args(
     const ffi::Buffer<ffi::DataType::S32>& Ai,
     const ffi::Buffer<ffi::DataType::S32>& Aj,
     const ffi::AnyBuffer::Dimensions ds_Ax,
@@ -122,15 +123,41 @@ void coo_to_csc_analyze(
     }
 }
 
-ffi::Error dot_f64(
-    const ffi::Buffer<ffi::DataType::S32> Ai,
-    const ffi::Buffer<ffi::DataType::S32> Aj,
-    const ffi::Buffer<ffi::DataType::F64> Ax,
-    const ffi::Buffer<ffi::DataType::F64> x,
-    ffi::Result<ffi::Buffer<ffi::DataType::F64>> b) {
-    auto ds_x = x.dimensions();
-    auto ds_Ax = Ax.dimensions();
-    ffi::Error err = validate_dot_f64_args(Ai, Aj, ds_Ax, ds_x);
+using Complex = std::complex<double>;
+
+template <typename T>
+struct KluTraits;
+
+template <>
+struct KluTraits<double> {
+    static klu_numeric* factor(int* Ap, int* Ai, double* Ax, klu_symbolic* Symbolic, klu_common* Common) {
+        return klu_factor(Ap, Ai, Ax, Symbolic, Common);
+    }
+    static int solve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, double* B, klu_common* Common) {
+        return klu_solve(Symbolic, Numeric, d, nrhs, B, Common);
+    }
+};
+
+template <>
+struct KluTraits<Complex> {
+    static klu_numeric* factor(int* Ap, int* Ai, Complex* Ax, klu_symbolic* Symbolic, klu_common* Common) {
+        return klu_z_factor(Ap, Ai, reinterpret_cast<double*>(Ax), Symbolic, Common);
+    }
+    static int solve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, Complex* B, klu_common* Common) {
+        return klu_z_solve(Symbolic, Numeric, d, nrhs, reinterpret_cast<double*>(B), Common);
+    }
+};
+
+template <typename T>
+ffi::Error dot_impl(
+    const ffi::Buffer<ffi::DataType::S32>& Ai,
+    const ffi::Buffer<ffi::DataType::S32>& Aj,
+    const ffi::AnyBuffer::Dimensions& ds_Ax,
+    const ffi::AnyBuffer::Dimensions& ds_x,
+    const T* _Ax,
+    const T* _x,
+    T* _b) {
+    ffi::Error err = validate_args(Ai, Aj, ds_Ax, ds_x);
     if (err.failure()) {
         return err;
     }
@@ -139,11 +166,6 @@ ffi::Error dot_f64(
     int n_col = (int)ds_x[1];
     int n_rhs = (int)ds_x[2];
     int n_nz = (int)ds_Ax[1];
-    const int* _Ai = Ai.typed_data();
-    const int* _Aj = Aj.typed_data();
-    const double* _Ax = Ax.typed_data();
-    const double* _x = x.typed_data();
-    double* _b = b->typed_data();
 
     // initialize empty result
     for (int i = 0; i < n_lhs * n_col * n_rhs; i++) {
@@ -156,6 +178,8 @@ ffi::Error dot_f64(
     // Loop order: m (batch) outer for better cache locality on Ax
     int i;
     int j;
+    const int* _Ai = Ai.typed_data();
+    const int* _Aj = Aj.typed_data();
     for (int m = 0; m < n_lhs; m++) {
         for (int n = 0; n < n_nz; n++) {
             i = _Ai[n];
@@ -166,6 +190,16 @@ ffi::Error dot_f64(
         }
     }
     return ffi::Error::Success();
+}
+
+ffi::Error dot_f64(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::F64> Ax,
+    const ffi::Buffer<ffi::DataType::F64> x,
+    ffi::Result<ffi::Buffer<ffi::DataType::F64>> b) {
+    return dot_impl<double>(Ai, Aj, Ax.dimensions(), x.dimensions(),
+                            Ax.typed_data(), x.typed_data(), b->typed_data());
 }
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(  // b = A x
@@ -184,49 +218,10 @@ ffi::Error dot_c128(
     const ffi::Buffer<ffi::DataType::C128> Ax,
     const ffi::Buffer<ffi::DataType::C128> x,
     ffi::Result<ffi::Buffer<ffi::DataType::C128>> b) {
-    auto ds_x = x.dimensions();
-    auto ds_Ax = Ax.dimensions();
-    ffi::Error err = validate_dot_f64_args(Ai, Aj, ds_Ax, ds_x);
-    if (err.failure()) {
-        return err;
-    }
-    int n_lhs = (int)ds_x[0];
-    int n_col = (int)ds_x[1];
-    int n_rhs = (int)ds_x[2];
-    int n_nz = (int)ds_Ax[1];
-    const int* _Ai = Ai.typed_data();
-    const int* _Aj = Aj.typed_data();
-    const double* _Ax = (double*)Ax.typed_data();
-    const double* _x = (double*)x.typed_data();
-    double* _b = (double*)b->typed_data();
-
-    // initialize empty result
-    for (int i = 0; i < 2 * n_lhs * n_col * n_rhs; i++) {
-        _b[i] = 0.0;
-    }
-
-    // fill result (all multi-dim arrays are row-major)
-    // x_mik = A_mij × x_mjk (einsum)
-    // sizes: m<n_lhs; i<n_col<--Ai; j<n_col<--Aj; k<n_rhs
-    // Loop order: m (batch) outer for better cache locality on Ax
-    int i;
-    int j;
-    for (int m = 0; m < n_lhs; m++) {
-        for (int n = 0; n < n_nz; n++) {
-            i = _Ai[n];
-            j = _Aj[n];
-            for (int k = 0; k < n_rhs; k++) {
-                _b[2 * (m * n_col * n_rhs + i * n_rhs + k)] +=                                        // real
-                    _Ax[2 * (m * n_nz + n)] * _x[2 * (m * n_col * n_rhs + j * n_rhs + k)]             // real*real
-                    - _Ax[2 * (m * n_nz + n) + 1] * _x[2 * (m * n_col * n_rhs + j * n_rhs + k) + 1];  // imag*imag
-                _b[2 * (m * n_col * n_rhs + i * n_rhs + k) + 1] +=                                    // imag
-                    _Ax[2 * (m * n_nz + n)] * _x[2 * (m * n_col * n_rhs + j * n_rhs + k) + 1]         // real*imag
-                    + _Ax[2 * (m * n_nz + n) + 1] * _x[2 * (m * n_col * n_rhs + j * n_rhs + k)];      // imag*real
-            }
-        }
-    }
-
-    return ffi::Error::Success();
+    return dot_impl<Complex>(Ai, Aj, Ax.dimensions(), x.dimensions(),
+                             reinterpret_cast<const Complex*>(Ax.typed_data()),
+                             reinterpret_cast<const Complex*>(x.typed_data()),
+                             reinterpret_cast<Complex*>(b->typed_data()));
 }
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(  // b = A x
@@ -239,15 +234,16 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(  // b = A x
         .Ret<ffi::Buffer<ffi::DataType::C128>>()  // b
 );
 
-ffi::Error solve_f64(
-    ffi::Buffer<ffi::DataType::S32> Ai,
-    ffi::Buffer<ffi::DataType::S32> Aj,
-    ffi::Buffer<ffi::DataType::F64> Ax,
-    ffi::Buffer<ffi::DataType::F64> b,
-    ffi::Result<ffi::Buffer<ffi::DataType::F64>> x) {
-    auto ds_b = b.dimensions();
-    auto ds_Ax = Ax.dimensions();
-    ffi::Error err = validate_dot_f64_args(Ai, Aj, ds_Ax, ds_b);
+template <typename T>
+ffi::Error solve_impl(
+    const ffi::Buffer<ffi::DataType::S32>& Ai,
+    const ffi::Buffer<ffi::DataType::S32>& Aj,
+    const ffi::AnyBuffer::Dimensions& ds_Ax,
+    const ffi::AnyBuffer::Dimensions& ds_b,
+    const T* _Ax,
+    const T* _b,
+    T* _x) {
+    ffi::Error err = validate_args(Ai, Aj, ds_Ax, ds_b);
     if (err.failure()) {
         return err;
     }
@@ -258,21 +254,18 @@ ffi::Error solve_f64(
     int n_nz = (int)ds_Ax[1];
     const int* _Ai = Ai.typed_data();
     const int* _Aj = Aj.typed_data();
-    const double* _Ax = Ax.typed_data();
-    const double* _b = b.typed_data();
-    double* _x = x->typed_data();
 
     // get COO -> CSC transformation information (using RAII for automatic cleanup)
     auto _Bk = std::make_unique<int[]>(n_nz);  // Ax -> Bx transformation indices
     auto _Bi = std::make_unique<int[]>(n_nz);
     auto _Bp = std::make_unique<int[]>(n_col + 1);
-    auto _Bx = std::make_unique<double[]>(n_nz);
+    auto _Bx = std::make_unique<T[]>(n_nz);
 
     coo_to_csc_analyze(n_col, n_nz, _Ai, _Aj, _Bi.get(), _Bp.get(), _Bk.get());
 
     // copy _b into _x_temp and transpose the last two dimensions since KLU expects col-major layout
     // _b itself won't be used anymore. KLU works on _x_temp in-place.
-    auto _x_temp = std::make_unique<double[]>(n_lhs * n_col * n_rhs);
+    auto _x_temp = std::make_unique<T[]>(n_lhs * n_col * n_rhs);
     for (int m = 0; m < n_lhs; m++) {
         for (int n = 0; n < n_col; n++) {
             for (int p = 0; p < n_rhs; p++) {
@@ -300,16 +293,16 @@ ffi::Error solve_f64(
         }
 
         // solve using KLU
-        Numeric = klu_factor(_Bp.get(), _Bi.get(), _Bx.get(), Symbolic, &Common);
+        Numeric = KluTraits<T>::factor(_Bp.get(), _Bi.get(), _Bx.get(), Symbolic, &Common);
         if (Numeric == nullptr || Common.status < KLU_OK) {
             klu_free_symbolic(&Symbolic, &Common);
-            return ffi::Error::InvalidArgument("klu_factor failed (singular matrix?)");
+            return ffi::Error::InvalidArgument("klu_factor/z_factor failed (singular matrix?)");
         }
-        klu_solve(Symbolic, Numeric, n_col, n_rhs, &_x_temp[n], &Common);
+        KluTraits<T>::solve(Symbolic, Numeric, n_col, n_rhs, &_x_temp[n], &Common);
         if (Common.status < KLU_OK) {
             klu_free_numeric(&Numeric, &Common);
             klu_free_symbolic(&Symbolic, &Common);
-            return ffi::Error::InvalidArgument("klu_solve failed");
+            return ffi::Error::InvalidArgument("klu_solve/z_solve failed");
         }
         klu_free_numeric(&Numeric, &Common);
     }
@@ -330,6 +323,16 @@ ffi::Error solve_f64(
     return ffi::Error::Success();
 }
 
+ffi::Error solve_f64(
+    ffi::Buffer<ffi::DataType::S32> Ai,
+    ffi::Buffer<ffi::DataType::S32> Aj,
+    ffi::Buffer<ffi::DataType::F64> Ax,
+    ffi::Buffer<ffi::DataType::F64> b,
+    ffi::Result<ffi::Buffer<ffi::DataType::F64>> x) {
+    return solve_impl<double>(Ai, Aj, Ax.dimensions(), b.dimensions(),
+                              Ax.typed_data(), b.typed_data(), x->typed_data());
+}
+
 XLA_FFI_DEFINE_HANDLER_SYMBOL(  // b = A x
     solve_f64_handler, solve_f64,
     ffi::Ffi::Bind()
@@ -346,90 +349,10 @@ ffi::Error solve_c128(
     const ffi::Buffer<ffi::DataType::C128> Ax,
     const ffi::Buffer<ffi::DataType::C128> b,
     ffi::Result<ffi::Buffer<ffi::DataType::C128>> x) {
-    auto ds_x = b.dimensions();
-    auto ds_Ax = Ax.dimensions();
-    ffi::Error err = validate_dot_f64_args(Ai, Aj, ds_Ax, ds_x);
-    if (err.failure()) {
-        return err;
-    }
-    int n_lhs = (int)ds_x[0];
-    int n_col = (int)ds_x[1];
-    int n_rhs = (int)ds_x[2];
-    int n_nz = (int)ds_Ax[1];
-    const int* _Ai = Ai.typed_data();
-    const int* _Aj = Aj.typed_data();
-    const double* _Ax = (double*)Ax.typed_data();
-    const double* _b = (double*)b.typed_data();
-    double* _x = (double*)x->typed_data();
-
-    // get COO -> CSC transformation information (using RAII for automatic cleanup)
-    auto _Bk = std::make_unique<int[]>(n_nz);       // Ax -> Bx transformation indices
-    auto _Bi = std::make_unique<int[]>(n_nz);       // CSC row indices
-    auto _Bp = std::make_unique<int[]>(n_col + 1);  // CSC column pointers
-    auto _Bx = std::make_unique<double[]>(2 * n_nz);
-    coo_to_csc_analyze(n_col, n_nz, _Ai, _Aj, _Bi.get(), _Bp.get(), _Bk.get());
-
-    // copy _b into _x_temp and transpose the last two dimensions since KLU expects col-major layout
-    // _b itself won't be used anymore. KLU works on _x_temp in-place.
-    auto _x_temp = std::make_unique<double[]>(2 * n_lhs * n_col * n_rhs);
-    for (int m = 0; m < n_lhs; m++) {
-        for (int n = 0; n < n_col; n++) {
-            for (int p = 0; p < n_rhs; p++) {
-                _x_temp[2 * (m * n_rhs * n_col + p * n_col + n)] = _b[2 * (m * n_col * n_rhs + n * n_rhs + p)];
-                _x_temp[2 * (m * n_rhs * n_col + p * n_col + n) + 1] = _b[2 * (m * n_col * n_rhs + n * n_rhs + p) + 1];
-            }
-        }
-    }
-
-    // initialize KLU for given sparsity pattern
-    klu_symbolic* Symbolic;
-    klu_numeric* Numeric;
-    klu_common Common;
-    klu_defaults(&Common);
-    Symbolic = klu_analyze(n_col, _Bp.get(), _Bi.get(), &Common);
-
-    // solve for all elements in batch:
-    // NOTE: same sparsity pattern for each element in batch assumed
-    for (int i = 0; i < n_lhs; i++) {
-        int m = i * n_nz;
-        int n = i * n_rhs * n_col;
-
-        // convert COO Ax to CSC Bx
-        for (int k = 0; k < n_nz; k++) {
-            _Bx[2 * k] = _Ax[2 * (m + _Bk[k])];
-            _Bx[2 * k + 1] = _Ax[2 * (m + _Bk[k]) + 1];
-        }
-
-        // solve using KLU
-        Numeric = klu_z_factor(_Bp.get(), _Bi.get(), _Bx.get(), Symbolic, &Common);
-        if (Numeric == nullptr || Common.status < KLU_OK) {
-            klu_free_symbolic(&Symbolic, &Common);
-            return ffi::Error::InvalidArgument("klu_z_factor failed (singular matrix?)");
-        }
-        klu_z_solve(Symbolic, Numeric, n_col, n_rhs, &_x_temp[2 * n], &Common);
-        if (Common.status < KLU_OK) {
-            klu_free_numeric(&Numeric, &Common);
-            klu_free_symbolic(&Symbolic, &Common);
-            return ffi::Error::InvalidArgument("klu_z_solve failed");
-        }
-        klu_free_numeric(&Numeric, &Common);
-    }
-
-    // copy _x_temp into _x and transpose the last two dimensions since JAX expects row-major layout
-    // NOTE: it feels a bit weird to have to do all this copying and transposing here. This might actually be
-    // pretty inefficient. Ideally I'd like to get rid of this transpose. Maybe just represent b/x in python
-    // as n_lhs x n_rhs x n_col in stead of n_lhs x n_col x n_rhs?
-    for (int m = 0; m < n_lhs; m++) {
-        for (int n = 0; n < n_col; n++) {
-            for (int p = 0; p < n_rhs; p++) {
-                _x[2 * (m * n_col * n_rhs + n * n_rhs + p)] = _x_temp[2 * (m * n_rhs * n_col + p * n_col + n)];
-                _x[2 * (m * n_col * n_rhs + n * n_rhs + p) + 1] = _x_temp[2 * (m * n_rhs * n_col + p * n_col + n) + 1];
-            }
-        }
-    }
-
-    klu_free_symbolic(&Symbolic, &Common);
-    return ffi::Error::Success();
+    return solve_impl<Complex>(Ai, Aj, Ax.dimensions(), b.dimensions(),
+                               reinterpret_cast<const Complex*>(Ax.typed_data()),
+                               reinterpret_cast<const Complex*>(b.typed_data()),
+                               reinterpret_cast<Complex*>(x->typed_data()));
 }
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(  // b = A x

--- a/klujax.cpp
+++ b/klujax.cpp
@@ -495,6 +495,255 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Ret<ffi::Buffer<ffi::DataType::C128>>()  // x
 );
 
+template <typename T>
+ffi::Error factor_impl(
+    const ffi::Buffer<ffi::DataType::S32>& Ai,
+    const ffi::Buffer<ffi::DataType::S32>& Aj,
+    const ffi::AnyBuffer::Dimensions& ds_Ax,
+    const ffi::Buffer<ffi::DataType::U64>& symbolic,
+    const T* _Ax,
+    uint64_t* _numeric) {
+    if (symbolic.element_count() != 1) return ffi::Error::InvalidArgument("symbolic must be scalar");
+    uint64_t sym_addr = *symbolic.typed_data();
+    if (sym_addr == 0) return ffi::Error::InvalidArgument("symbolic pointer is null");
+    klu_symbolic* Symbolic = reinterpret_cast<klu_symbolic*>(sym_addr);
+
+    // We reuse validate_args but we need a dummy ds_x (b) to satisfy it.
+    // We construct a dummy ds_b that matches ds_Ax's batch size.
+    int n_lhs = (int)ds_Ax[0];
+    int n_nz = (int)ds_Ax[1];
+    // We need n_col. We can't easily get it from just Ax/Ai/Aj without passing it or inferring it.
+    // However, Symbolic->n is n_col.
+    int n_col = Symbolic->n;
+    
+    // validate_args expects ds_x to be [n_lhs, n_col, n_rhs].
+    // We can just check Ai/Aj/Ax consistency manually or construct a fake vector.
+    // Let's do manual consistency check for Ai/Aj/Ax to avoid constructing fake vector.
+    if (Ai.dimensions().size() != 1 || Aj.dimensions().size() != 1) return ffi::Error::InvalidArgument("Ai/Aj must be 1D");
+    if (Ai.dimensions()[0] != n_nz || Aj.dimensions()[0] != n_nz) return ffi::Error::InvalidArgument("Ai/Aj size mismatch with Ax");
+
+    const int* _Ai = Ai.typed_data();
+    const int* _Aj = Aj.typed_data();
+
+    // get COO -> CSC transformation information
+    auto _Bk = std::make_unique<int[]>(n_nz);
+    auto _Bi = std::make_unique<int[]>(n_nz);
+    auto _Bp = std::make_unique<int[]>(n_col + 1);
+    auto _Bx = std::make_unique<T[]>(n_nz);
+
+    coo_to_csc_analyze(n_col, n_nz, _Ai, _Aj, _Bi.get(), _Bp.get(), _Bk.get());
+
+    klu_common Common;
+    klu_defaults(&Common);
+
+    for (int i = 0; i < n_lhs; i++) {
+        int m = i * n_nz;
+        // convert COO Ax to CSC Bx
+        for (int k = 0; k < n_nz; k++) {
+            _Bx[k] = _Ax[m + _Bk[k]];
+        }
+
+        klu_numeric* Numeric = KluTraits<T>::factor(_Bp.get(), _Bi.get(), _Bx.get(), Symbolic, &Common);
+        if (Numeric == nullptr || Common.status < KLU_OK) {
+             // Cleanup already allocated numerics in this batch?
+             // For simplicity, we return error and let user handle cleanup (or leak, but this is exception path).
+             // Ideally we should cleanup.
+             for(int j=0; j<i; j++) {
+                 klu_numeric* num = reinterpret_cast<klu_numeric*>(_numeric[j]);
+                 klu_free_numeric(&num, &Common);
+             }
+             return ffi::Error::InvalidArgument("klu_factor/z_factor failed (singular matrix?)");
+        }
+        _numeric[i] = reinterpret_cast<uint64_t>(Numeric);
+    }
+    return ffi::Error::Success();
+}
+
+ffi::Error factor_f64(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::F64> Ax,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    ffi::Result<ffi::Buffer<ffi::DataType::U64>> numeric) {
+    return factor_impl<double>(Ai, Aj, Ax.dimensions(), symbolic, Ax.typed_data(), numeric->typed_data());
+}
+
+ffi::Error factor_c128(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::C128> Ax,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    ffi::Result<ffi::Buffer<ffi::DataType::U64>> numeric) {
+    return factor_impl<Complex>(Ai, Aj, Ax.dimensions(), symbolic, 
+                                reinterpret_cast<const Complex*>(Ax.typed_data()), 
+                                numeric->typed_data());
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    factor_f64_handler, factor_f64,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()
+        .Ret<ffi::Buffer<ffi::DataType::U64>>()
+);
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    factor_c128_handler, factor_c128,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()
+        .Ret<ffi::Buffer<ffi::DataType::U64>>()
+);
+
+template <typename T>
+ffi::Error solve_with_numeric_impl(
+    const ffi::AnyBuffer::Dimensions& ds_b,
+    const ffi::AnyBuffer::Dimensions& ds_x,
+    const ffi::Buffer<ffi::DataType::U64>& symbolic,
+    const ffi::Buffer<ffi::DataType::U64>& numeric,
+    const T* _b,
+    T* _x) {
+    
+    if (symbolic.element_count() != 1) return ffi::Error::InvalidArgument("symbolic must be scalar");
+    uint64_t sym_addr = *symbolic.typed_data();
+    if (sym_addr == 0) return ffi::Error::InvalidArgument("symbolic pointer is null");
+    klu_symbolic* Symbolic = reinterpret_cast<klu_symbolic*>(sym_addr);
+
+    if (ds_b.size() != 3) return ffi::Error::InvalidArgument("b must be 3D");
+    if (ds_x.size() != 3) return ffi::Error::InvalidArgument("x must be 3D");
+
+    int n_lhs_x = (int)ds_x[0];
+    int n_col = (int)ds_x[1];
+    int n_rhs = (int)ds_x[2];
+
+    int n_lhs_b = (int)ds_b[0];
+    if (ds_b[1] != n_col || ds_b[2] != n_rhs) {
+        return ffi::Error::InvalidArgument("b and x dimension mismatch");
+    }
+    
+    int n_numeric = numeric.element_count();
+    const uint64_t* _numeric = numeric.typed_data();
+
+    // Determine actual output batch size
+    int n_lhs = n_lhs_x;  // x determines output size
+    
+    bool broadcast_numeric = (n_numeric == 1);
+    bool broadcast_b = (n_lhs_b == 1);
+    
+    // Validate broadcasting rules
+    if (!broadcast_numeric && n_numeric != n_lhs) {
+        return ffi::Error::InvalidArgument("numeric batch size mismatch with x: got " + 
+                                          std::to_string(n_numeric) + " vs " + std::to_string(n_lhs));
+    }
+    if (!broadcast_b && n_lhs_b != n_lhs) {
+        return ffi::Error::InvalidArgument("b batch size mismatch with x: got " + 
+                                          std::to_string(n_lhs_b) + " vs " + std::to_string(n_lhs));
+    }
+
+    auto _x_temp = std::make_unique<T[]>(n_lhs * n_col * n_rhs);
+    
+    // Copy b to x_temp (transpose) with broadcasting
+    for (int m = 0; m < n_lhs; m++) {
+        int m_b = broadcast_b ? 0 : m;
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x_temp[m * n_rhs * n_col + p * n_col + n] = _b[m_b * n_col * n_rhs + n * n_rhs + p];
+            }
+        }
+    }
+
+    klu_common Common;
+    klu_defaults(&Common);
+
+    for (int i = 0; i < n_lhs; i++) {
+        int n = i * n_rhs * n_col;
+        uint64_t num_addr = broadcast_numeric ? _numeric[0] : _numeric[i];
+        if (num_addr == 0) return ffi::Error::InvalidArgument("numeric pointer is null");
+        
+        klu_numeric* Numeric = reinterpret_cast<klu_numeric*>(num_addr);
+        KluTraits<T>::solve(Symbolic, Numeric, n_col, n_rhs, &_x_temp[n], &Common);
+        
+        if (Common.status < KLU_OK) {
+            return ffi::Error::InvalidArgument("klu_solve/z_solve failed");
+        }
+    }
+
+    // Copy x_temp to x (transpose)
+    for (int m = 0; m < n_lhs; m++) {
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x[m * n_col * n_rhs + n * n_rhs + p] = _x_temp[m * n_rhs * n_col + p * n_col + n];
+            }
+        }
+    }
+    return ffi::Error::Success();
+}
+
+ffi::Error solve_with_numeric_f64(
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    const ffi::Buffer<ffi::DataType::F64> b,
+    ffi::Result<ffi::Buffer<ffi::DataType::F64>> x) {
+    return solve_with_numeric_impl<double>(b.dimensions(), x->dimensions(), symbolic, numeric, b.typed_data(), x->typed_data());
+}
+
+ffi::Error solve_with_numeric_c128(
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    const ffi::Buffer<ffi::DataType::C128> b,
+    ffi::Result<ffi::Buffer<ffi::DataType::C128>> x) {
+    return solve_with_numeric_impl<Complex>(b.dimensions(), x->dimensions(), symbolic, numeric, 
+                                            reinterpret_cast<const Complex*>(b.typed_data()), 
+                                            reinterpret_cast<Complex*>(x->typed_data()));
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    solve_with_numeric_f64_handler, solve_with_numeric_f64,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()
+        .Ret<ffi::Buffer<ffi::DataType::F64>>()
+);
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    solve_with_numeric_c128_handler, solve_with_numeric_c128,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()
+        .Ret<ffi::Buffer<ffi::DataType::C128>>()
+);
+
+ffi::Error free_numeric(
+    const ffi::Buffer<ffi::DataType::U64> numeric) {
+    
+    int n = numeric.element_count();
+    const uint64_t* _numeric = numeric.typed_data();
+    
+    klu_common Common;
+    klu_defaults(&Common);
+
+    for(int i=0; i<n; i++) {
+        uint64_t addr = _numeric[i];
+        if (addr != 0) {
+            klu_numeric* Numeric = reinterpret_cast<klu_numeric*>(addr);
+            klu_free_numeric(&Numeric, &Common);
+        }
+    }
+    return ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    free_numeric_handler, free_numeric,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()
+);
+
 ffi::Error free_symbolic(
     const ffi::Buffer<ffi::DataType::U64> symbolic) {
     if (symbolic.element_count() != 1) {
@@ -587,6 +836,16 @@ PYBIND11_MODULE(klujax_cpp, m) {
           []() { return py::capsule((void*)&solve_with_symbol_f64_handler); });
     m.def("solve_with_symbol_c128",
           []() { return py::capsule((void*)&solve_with_symbol_c128_handler); });
+    m.def("factor_f64",
+          []() { return py::capsule((void*)&factor_f64_handler); });
+    m.def("factor_c128",
+          []() { return py::capsule((void*)&factor_c128_handler); });
+    m.def("solve_with_numeric_f64",
+          []() { return py::capsule((void*)&solve_with_numeric_f64_handler); });
+    m.def("solve_with_numeric_c128",
+          []() { return py::capsule((void*)&solve_with_numeric_c128_handler); });
+    m.def("free_numeric",
+          []() { return py::capsule((void*)&free_numeric_handler); });
     m.def("analyze",
           []() { return py::capsule((void*)&analyze_handler); });
     m.def("free_symbolic",


### PR DESCRIPTION
related to #16 

# Added support for split solve
The subroutines of klujax.solve are exposed so that they can be optimized for different types of solvers
* `klujax.analyze`: Inspects the sparsity pattern ($A_i, A_j$) to find optimal permutations and block triangular forms. This depends only on the structure of the matrix.
* `klujax.solve_with_symbol`: Solves the system with the sparsity pattern from klujax analyze. For transient simulations where the circuit topology is not changing from step to step, significant performance gains can be achieved by reusing the result from the analyze step
* `klujax.factor`:  Performs the actual LU decomposition. This depends on the values ($A_x$) and requires a symbolic handle.
* `klujax.solve_with_numeric`:  Executes forward and backward substitution to find $x$. This depends on the right-hand side ($b$) and requires a numeric handle.

## Some benchmarks
1000 node LC ladder circuit transient simulation (2301 time steps):

* `klujax.solve`: 1.51 s ± 129 ms per loop
* `klujax.solve_with_symbol`: 908 ms ± 109 ms per loop

so effectively, the analyze part of the klu calculation takes a little over 30% of the time which is not needed if the circuit does not change topology.

## Pointer handling
As the analyze and factor methods return C++ pointers, extra care has to be taken so as to free/not double free the memory. The `KLUHandleManager` should free the associated memory when it reaches the garbage collector and the recommendation (in the docs) is to perform the analyze step before jit compiling.


## Other changes
* Cleaned up some of the duplicate C++ code by means of a template to switch between f64 and c128 use cases
