### PR TITLE
Bug: release pointer after Jax deleted

### DIFF
--- a/klujax.py
+++ b/klujax.py
@@ -169,8 +169,14 @@ class KLUHandleManager:
 
     def close(self) -> None:
         """Release the C++ resource if this instance is the owner."""
+        # Safety check: If the interpreter is shutting down, 'jax' might be None.
+        # If so, we can simply return, as the OS will reclaim the memory momentarily.
+        if jax is None:
+            return
+
         if self._freed or isinstance(self.handle, jax.core.Tracer):
             return
+
         if self._owner and self.free_callable:
             try:
                 self.free_callable(self.handle)


### PR DESCRIPTION
Ran into the following bug this morning when running pytest on another project:

```
Exception ignored in: <function KLUHandleManager.__del__ at 0x7f49d38e1ee0>
Traceback (most recent call last):
  File "/home/chris/code/klujax/klujax/klujax.py", line 194, in __del__
  File "/home/chris/code/klujax/klujax/klujax.py", line 172, in close
AttributeError: 'NoneType' object has no attribute 'core'
Exception ignored in: <function KLUHandleManager.__del__ at 0x7f497f10a840>
Traceback (most recent call last):
  File "/home/chris/code/klurs/klurs/src/klujax_rs.py", line 105, in __del__
  File "/home/chris/code/klurs/klurs/src/klujax_rs.py", line 86, in close
AttributeError: 'NoneType' object has no attribute 'Tracer'
Exception ignored in: <function KLUHandleManager.__del__ at 0x7f49d38e1ee0>
Traceback (most recent call last):
  File "/home/chris/code/klujax/klujax/klujax.py", line 194, in __del__
  File "/home/chris/code/klujax/klujax/klujax.py", line 172, in close
AttributeError: 'NoneType' object has no attribute 'core'
Exception ignored in: <function KLUHandleManager.__del__ at 0x7f497f10a840>
Traceback (most recent call last):
  File "/home/chris/code/klurs/klurs/src/klujax_rs.py", line 105, in __del__
  File "/home/chris/code/klurs/klurs/src/klujax_rs.py", line 86, in close
AttributeError: 'NoneType' object has no attribute 'Tracer'
Exception ignored in: <function KLUHandleManager.__del__ at 0x7f49d38e1ee0>
Traceback (most recent call last):
  File "/home/chris/code/klujax/klujax/klujax.py", line 194, in __del__
  File "/home/chris/code/klujax/klujax/klujax.py", line 172, in close
AttributeError: 'NoneType' object has no attribute 'core'
Exception ignored in: <function KLUHandleManager.__del__ at 0x7f49d38e1ee0>
Traceback (most recent call last):
  File "/home/chris/code/klujax/klujax/klujax.py", line 194, in __del__
  File "/home/chris/code/klujax/klujax/klujax.py", line 172, in close
AttributeError: 'NoneType' object has no attribute 'core
```

If seems python's garbage collector teardown is performed in a semi-random order whereby objects are just set to `None`. In this case, jax is set to None before `KLUHandleManager.close` so we need to check if jax is not None in this case.

Also note, once the python/c++ code completes (interpreter closes), the OS should reclaim the memory anyway (if I understand things)

