### PR TITLE
Bug trace error for symbolic

### DIFF
--- a/klujax.py
+++ b/klujax.py
@@ -199,12 +199,14 @@ class KLUHandleManager:
         if hasattr(self, "close"):
             self.close()
 
-def _klu_flatten(obj: KLUHandleManager) -> Tuple[Tuple[Array], Tuple[Callable]]:
-    return (obj.handle,), (obj.free_callable,)
+def _klu_flatten(obj: KLUHandleManager) -> tuple[tuple[()], tuple[Array, Callable]]:
+    # No leaves — handle and callable are both static aux data
+    return (), (obj.handle, obj.free_callable)
 
-def _klu_unflatten(aux: Tuple[Callable], children: Tuple[Array]) -> KLUHandleManager:
-    # JAX-reconstructed objects are marked as non-owners to prevent double-free.
-    return KLUHandleManager(children[0], free_callable=aux[0], owner=False)
+
+def _klu_unflatten(aux: tuple[Array, Callable], children: tuple[()]) -> KLUHandleManager:
+    handle, free_callable = aux
+    return KLUHandleManager(handle, free_callable=free_callable, owner=False)
 
 jax.tree_util.register_pytree_node(KLUHandleManager, _klu_flatten, _klu_unflatten)
 

--- a/tests.py
+++ b/tests.py
@@ -349,27 +349,42 @@ def _is_almost_equal(arr1, arr2):
         return False
     else:
         return True
-    
+
 def test_solve_with_symbol_jvp():
 
     Ai = jnp.array([0, 1], dtype=jnp.int32)
     Aj = jnp.array([0, 1], dtype=jnp.int32)
     Ax = jnp.array([2.0, 4.0], dtype=jnp.float64) # Values
     b = jnp.array([10.0, 20.0], dtype=jnp.float64)
-    
+
     # Pre-compute symbolic factorization
     n_col = 2
     symbolic = klujax.analyze(Ai, Aj, n_col)
-    
+
     def solve_step(Ax_vals, b_vec):
         return klujax.solve_with_symbol(Ai, Aj, Ax_vals, b_vec, symbolic)
 
     # Tangents (perturbations)
     tangent_Ax = jnp.array([0.1, 0.1], dtype=jnp.float64)
     tangent_b = jnp.array([0.0, 0.0], dtype=jnp.float64)
-    
+
     # This triggers the JVP rule lookup
     primals, tangents = jax.jvp(solve_step, (Ax, b), (tangent_Ax, tangent_b))
-    assert primals.shape == (2,)
-    assert tangents.shape == (2,)
-    
+    assert primals.shape == (2,)  # noqa: S101
+    assert tangents.shape == (2,)  # noqa: S101
+
+def use_handle(manager, x):
+    """Simulates any function requiring a concrete handle (e.g. a C pointer)."""
+    assert not isinstance(manager.handle, jax.core.Tracer), (
+        "Handle was traced! Got a Tracer instead of a concrete value."
+    )
+    return x * 2.0
+
+def test_registration_traces_handle():
+
+    manager = klujax.KLUHandleManager(jnp.array(0xDEADBEEF, dtype=jnp.int64),
+                                      free_callable=lambda x: None)
+
+    fn = jax.jit(use_handle)
+    result = fn(manager, jnp.array(1.0))
+    assert result == 2.0


### PR DESCRIPTION
Related to #21 

Added additional testing for `KLUHandleManager` to verify it does not cause issues during `jit`,  `grad ` and `vmap`