### PR TITLE
Klu refactor

### DIFF
--- a/klujax.cpp
+++ b/klujax.cpp
@@ -134,6 +134,9 @@ struct KluTraits<double> {
     static klu_numeric* factor(int* Ap, int* Ai, double* Ax, klu_symbolic* Symbolic, klu_common* Common) {
         return klu_factor(Ap, Ai, Ax, Symbolic, Common);
     }
+    static int refactor(int* Ap, int* Ai, double* Ax, klu_symbolic* Symbolic, klu_numeric* Numeric, klu_common* Common) {
+        return klu_refactor(Ap, Ai, Ax, Symbolic, Numeric, Common);
+    }
     static int solve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, double* B, klu_common* Common) {
         return klu_solve(Symbolic, Numeric, d, nrhs, B, Common);
     }
@@ -143,6 +146,9 @@ template <>
 struct KluTraits<Complex> {
     static klu_numeric* factor(int* Ap, int* Ai, Complex* Ax, klu_symbolic* Symbolic, klu_common* Common) {
         return klu_z_factor(Ap, Ai, reinterpret_cast<double*>(Ax), Symbolic, Common);
+    }
+    static int refactor(int* Ap, int* Ai, Complex* Ax, klu_symbolic* Symbolic, klu_numeric* Numeric, klu_common* Common) {
+        return klu_z_refactor(Ap, Ai, reinterpret_cast<double*>(Ax), Symbolic, Numeric, Common);
     }
     static int solve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, Complex* B, klu_common* Common) {
         return klu_z_solve(Symbolic, Numeric, d, nrhs, reinterpret_cast<double*>(B), Common);
@@ -594,6 +600,108 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
 );
 
 template <typename T>
+ffi::Error refactor_impl(
+    const ffi::Buffer<ffi::DataType::S32>& Ai,
+    const ffi::Buffer<ffi::DataType::S32>& Aj,
+    const ffi::AnyBuffer::Dimensions& ds_Ax,
+    const ffi::Buffer<ffi::DataType::U64>& symbolic,
+    const ffi::Buffer<ffi::DataType::U64>& numeric,
+    const T* _Ax,
+    uint64_t* _out_numeric) {
+    if (symbolic.element_count() != 1) return ffi::Error::InvalidArgument("symbolic must be scalar");
+    uint64_t sym_addr = *symbolic.typed_data();
+    if (sym_addr == 0) return ffi::Error::InvalidArgument("symbolic pointer is null");
+    klu_symbolic* Symbolic = reinterpret_cast<klu_symbolic*>(sym_addr);
+
+    int n_lhs = (int)ds_Ax[0];
+    int n_nz = (int)ds_Ax[1];
+    int n_col = Symbolic->n;
+
+    if (Ai.dimensions().size() != 1 || Aj.dimensions().size() != 1) return ffi::Error::InvalidArgument("Ai/Aj must be 1D");
+    if (Ai.dimensions()[0] != n_nz || Aj.dimensions()[0] != n_nz) return ffi::Error::InvalidArgument("Ai/Aj size mismatch with Ax");
+    if ((int)numeric.element_count() != n_lhs) return ffi::Error::InvalidArgument("numeric array size must match n_lhs");
+
+    const int* _Ai = Ai.typed_data();
+    const int* _Aj = Aj.typed_data();
+    const uint64_t* _numeric = numeric.typed_data();
+
+    // get COO -> CSC transformation information
+    auto _Bk = std::make_unique<int[]>(n_nz);
+    auto _Bi = std::make_unique<int[]>(n_nz);
+    auto _Bp = std::make_unique<int[]>(n_col + 1);
+    auto _Bx = std::make_unique<T[]>(n_nz);
+
+    coo_to_csc_analyze(n_col, n_nz, _Ai, _Aj, _Bi.get(), _Bp.get(), _Bk.get());
+
+    klu_common Common;
+    klu_defaults(&Common);
+
+    for (int i = 0; i < n_lhs; i++) {
+        uint64_t num_addr = _numeric[i];
+        if (num_addr == 0) return ffi::Error::InvalidArgument("numeric pointer is null");
+        klu_numeric* Numeric = reinterpret_cast<klu_numeric*>(num_addr);
+
+        int m = i * n_nz;
+        // convert COO Ax to CSC Bx
+        for (int k = 0; k < n_nz; k++) {
+            _Bx[k] = _Ax[m + _Bk[k]];
+        }
+
+        int status = KluTraits<T>::refactor(_Bp.get(), _Bi.get(), _Bx.get(), Symbolic, Numeric, &Common);
+        if (!status || Common.status < KLU_OK) {
+            return ffi::Error::InvalidArgument("klu_refactor/z_refactor failed (singular matrix?)");
+        }
+        // Pass through the same pointer so XLA sees a data dependency: refactor → solve
+        _out_numeric[i] = num_addr;
+    }
+    return ffi::Error::Success();
+}
+
+ffi::Error refactor_f64(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::F64> Ax,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    ffi::Result<ffi::Buffer<ffi::DataType::U64>> out_numeric) {
+    return refactor_impl<double>(Ai, Aj, Ax.dimensions(), symbolic, numeric, Ax.typed_data(), out_numeric->typed_data());
+}
+
+ffi::Error refactor_c128(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::C128> Ax,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    ffi::Result<ffi::Buffer<ffi::DataType::U64>> out_numeric) {
+    return refactor_impl<Complex>(Ai, Aj, Ax.dimensions(), symbolic, numeric,
+                                  reinterpret_cast<const Complex*>(Ax.typed_data()),
+                                  out_numeric->typed_data());
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    refactor_f64_handler, refactor_f64,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Ai
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Aj
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()  // Ax
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // symbolic
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // numeric (input handles)
+        .Ret<ffi::Buffer<ffi::DataType::U64>>()  // out_numeric (same handles, for XLA dep edge)
+);
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    refactor_c128_handler, refactor_c128,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Ai
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Aj
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()  // Ax
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // symbolic
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // numeric (input handles)
+        .Ret<ffi::Buffer<ffi::DataType::U64>>()  // out_numeric (same handles, for XLA dep edge)
+);
+
+template <typename T>
 ffi::Error solve_with_numeric_impl(
     const ffi::AnyBuffer::Dimensions& ds_b,
     const ffi::AnyBuffer::Dimensions& ds_x,
@@ -882,4 +990,8 @@ PYBIND11_MODULE(klujax_cpp, m) {
           []() { return py::capsule((void*)&analyze_handler); });
     m.def("free_symbolic",
           []() { return py::capsule((void*)&free_symbolic_handler); });
+    m.def("refactor_f64",
+          []() { return py::capsule((void*)&refactor_f64_handler); });
+    m.def("refactor_c128",
+          []() { return py::capsule((void*)&refactor_c128_handler); });
 }

--- a/klujax.py
+++ b/klujax.py
@@ -4,7 +4,7 @@
 
 __version__ = "0.4.8"
 __author__ = "Floris Laporte"
-__all__ = ["analyze", "coalesce", "dot", "factor", "free_numeric", "free_symbolic", "solve", "solve_with_numeric", "solve_with_symbol"]
+__all__ = ["analyze", "coalesce", "dot", "factor", "free_numeric", "free_symbolic", "refactor", "solve", "solve_with_numeric", "solve_with_symbol"]
 
 # Imports =============================================================================
 
@@ -380,6 +380,40 @@ def factor(Ai: Array, Aj: Array, Ax: Array, symbolic: Union[KLUHandleManager, Ar
     return KLUHandleManager(raw_numeric, free_numeric, owner=True)
 
 @jax.jit
+def _refactor_jit(Ai: Array, Aj: Array, Ax: Array, sym_h: Array, num_h: Array) -> Array:
+    dummy_b = jnp.zeros((1,), dtype=Ax.dtype)
+    Ai, Aj, Ax, _, _ = validate_args(Ai, Aj, Ax, dummy_b)
+    prim = refactor_c128 if Ax.dtype in COMPLEX_DTYPES else refactor_f64
+    return prim.bind(Ai, Aj, Ax, sym_h, num_h)
+
+def refactor(Ai: Array, Aj: Array, Ax: Array, numeric: Union[KLUHandleManager, Array], symbolic: Union[KLUHandleManager, Array]) -> KLUHandleManager:
+    """Re-factorize matrix A numerically, reusing the symbolic analysis.
+
+    Use when the sparsity pattern is unchanged but values have changed.
+    Modifies the numeric factorization in-place. Faster than calling factor().
+
+    Returns a KLUHandleManager holding the same underlying pointer as the input
+    numeric handle. The returned handle must be threaded into subsequent
+    solve_with_numeric calls so that XLA/JAX sees the dependency edge:
+    factor → refactor → solve.
+
+    Args:
+        Ai: [n_nz; int32]: the row indices of the sparse matrix A
+        Aj: [n_nz; int32]: the column indices of the sparse matrix A
+        Ax: [n_lhs? x n_nz; float64|complex128]: the values of the sparse matrix A
+        numeric: [KLUHandleManager|Array]: existing numeric factorization (modified in-place)
+        symbolic: [KLUHandleManager|Array]: the symbolic analysis object or handle
+
+    Returns:
+        numeric: [KLUHandleManager]: the updated numeric handle (same pointer, for XLA dep tracking)
+
+    """
+    num_h = getattr(numeric, "handle", numeric)
+    sym_h = getattr(symbolic, "handle", symbolic)
+    raw_handle = _refactor_jit(Ai, Aj, Ax, sym_h, num_h)
+    return KLUHandleManager(raw_handle, free_numeric, owner=False)
+
+@jax.jit
 def _solve_with_numeric_jit(num_h: Array, b: Array, sym_h: Array) -> Array:
     prim = solve_with_numeric_c128 if b.dtype in COMPLEX_DTYPES else solve_with_numeric_f64
     return prim.bind(sym_h.astype(jnp.uint64), num_h.astype(jnp.uint64), b)
@@ -421,6 +455,8 @@ factor_c128 = jax.extend.core.Primitive("factor_c128")
 solve_with_numeric_f64 = jax.extend.core.Primitive("solve_with_numeric_f64")
 solve_with_numeric_c128 = jax.extend.core.Primitive("solve_with_numeric_c128")
 free_numeric_p = jax.extend.core.Primitive("free_numeric")
+refactor_f64 = jax.extend.core.Primitive("refactor_f64")
+refactor_c128 = jax.extend.core.Primitive("refactor_c128")
 
 # Implementations =====================================================================
 
@@ -471,6 +507,18 @@ def factor_c128_impl(Ai, Aj, Ax, symbolic):
     n_lhs = Ax.shape[0]
     call = jax.ffi.ffi_call("factor_c128", jax.ShapeDtypeStruct((n_lhs,), jnp.uint64))
     return call(Ai, Aj, Ax, symbolic)
+
+@refactor_f64.def_impl
+def refactor_f64_impl(Ai, Aj, Ax, symbolic, numeric):
+    n_lhs = Ax.shape[0]
+    call = jax.ffi.ffi_call("refactor_f64", jax.ShapeDtypeStruct((n_lhs,), jnp.uint64))
+    return call(Ai, Aj, Ax, symbolic, numeric)
+
+@refactor_c128.def_impl
+def refactor_c128_impl(Ai, Aj, Ax, symbolic, numeric):
+    n_lhs = Ax.shape[0]
+    call = jax.ffi.ffi_call("refactor_c128", jax.ShapeDtypeStruct((n_lhs,), jnp.uint64))
+    return call(Ai, Aj, Ax, symbolic, numeric)
 
 @solve_with_numeric_f64.def_impl
 def solve_with_numeric_f64_impl(symbolic, numeric, b):
@@ -598,6 +646,14 @@ jax.ffi.register_ffi_target("factor_c128", klujax_cpp.factor_c128(), platform="c
 factor_c128_low = mlir.lower_fun(factor_c128_impl, multiple_results=False)
 mlir.register_lowering(factor_c128, factor_c128_low)
 
+jax.ffi.register_ffi_target("refactor_f64", klujax_cpp.refactor_f64(), platform="cpu")
+refactor_f64_low = mlir.lower_fun(refactor_f64_impl, multiple_results=False)
+mlir.register_lowering(refactor_f64, refactor_f64_low)
+
+jax.ffi.register_ffi_target("refactor_c128", klujax_cpp.refactor_c128(), platform="cpu")
+refactor_c128_low = mlir.lower_fun(refactor_c128_impl, multiple_results=False)
+mlir.register_lowering(refactor_c128, refactor_c128_low)
+
 jax.ffi.register_ffi_target("solve_with_numeric_f64", klujax_cpp.solve_with_numeric_f64(), platform="cpu")
 solve_with_numeric_f64_low = mlir.lower_fun(solve_with_numeric_f64_impl, multiple_results=False)
 mlir.register_lowering(solve_with_numeric_f64, solve_with_numeric_f64_low)
@@ -637,6 +693,11 @@ def free_symbolic_abstract_eval(symbolic: Array) -> None:  # noqa: ARG001
 @factor_f64.def_abstract_eval
 @factor_c128.def_abstract_eval
 def factor_abstract_eval(Ai, Aj, Ax, symbolic):
+    return ShapedArray((Ax.shape[0],), jnp.uint64)
+
+@refactor_f64.def_abstract_eval
+@refactor_c128.def_abstract_eval
+def refactor_abstract_eval(Ai, Aj, Ax, symbolic, numeric):
     return ShapedArray((Ax.shape[0],), jnp.uint64)
 
 @solve_with_numeric_f64.def_abstract_eval

--- a/klujax.py
+++ b/klujax.py
@@ -871,6 +871,46 @@ def solve_with_numeric_c128_vmap(
 batching.primitive_batchers[solve_with_numeric_c128] = solve_with_numeric_c128_vmap
 
 
+def factor_f64_vmap(
+    vector_arg_values: tuple[Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_factor(factor_f64, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[factor_f64] = factor_f64_vmap
+
+
+def factor_c128_vmap(
+    vector_arg_values: tuple[Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_factor(factor_c128, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[factor_c128] = factor_c128_vmap
+
+
+def refactor_f64_vmap(
+    vector_arg_values: tuple[Array, Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_refactor(refactor_f64, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[refactor_f64] = refactor_f64_vmap
+
+
+def refactor_c128_vmap(
+    vector_arg_values: tuple[Array, Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_refactor(refactor_c128, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[refactor_c128] = refactor_c128_vmap
+
+
 def general_vmap(
     prim: jax.extend.core.Primitive,
     vector_arg_values: tuple[Array, Array, Array, Array],
@@ -1055,6 +1095,99 @@ def general_vmap_with_numeric(
         b = b.reshape(b.shape[0], b.shape[1] * b.shape[2])
         return prim.bind(symbolic, numeric, b).reshape(*shape), 2
     
+    msg = "vmap failed. Please select an axis to vectorize over."
+    raise ValueError(msg)
+
+
+def general_vmap_factor(
+    prim: jax.extend.core.Primitive,
+    vector_arg_values: tuple[Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    Ai, Aj, Ax, symbolic = vector_arg_values
+    aAi, aAj, aAx, asymbolic = batch_axes
+
+    if aAi is not None:
+        msg = "Ai cannot be vectorized."
+        raise ValueError(msg)
+
+    if aAj is not None:
+        msg = "Aj cannot be vectorized."
+        raise ValueError(msg)
+
+    if asymbolic is not None:
+        msg = "symbolic handle cannot be vectorized."
+        raise ValueError(msg)
+
+    if aAx is not None:
+        if Ax.ndim != 3:
+            msg = f"Ax should be 3D when vectorizing over it. Got: {Ax.shape=}."
+            raise ValueError(msg)
+        Ax = jnp.moveaxis(Ax, aAx, 0)
+        batch, n_lhs, n_vals = Ax.shape
+        Ax = Ax.reshape(batch * n_lhs, n_vals)
+        return prim.bind(Ai, Aj, Ax, symbolic).reshape(batch, n_lhs), 0
+
+    msg = "vmap failed. Please select an axis to vectorize over."
+    raise ValueError(msg)
+
+
+def general_vmap_refactor(
+    prim: jax.extend.core.Primitive,
+    vector_arg_values: tuple[Array, Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    Ai, Aj, Ax, symbolic, numeric = vector_arg_values
+    aAi, aAj, aAx, asymbolic, anumeric = batch_axes
+
+    if aAi is not None:
+        msg = "Ai cannot be vectorized."
+        raise ValueError(msg)
+
+    if aAj is not None:
+        msg = "Aj cannot be vectorized."
+        raise ValueError(msg)
+
+    if asymbolic is not None:
+        msg = "symbolic handle cannot be vectorized."
+        raise ValueError(msg)
+
+    if aAx is not None and anumeric is not None:
+        if Ax.ndim != 3 or numeric.ndim != 2:
+            msg = (
+                "Ax and numeric should be 3D and 2D respectively when vectorizing "
+                f"over them simultaneously. Got: {Ax.shape=}; {numeric.shape=}."
+            )
+            raise ValueError(msg)
+        Ax = jnp.moveaxis(Ax, aAx, 0)
+        numeric = jnp.moveaxis(numeric, anumeric, 0)
+        batch, n_lhs, n_vals = Ax.shape
+        Ax = Ax.reshape(batch * n_lhs, n_vals)
+        numeric = numeric.reshape(batch * n_lhs)
+        return prim.bind(Ai, Aj, Ax, symbolic, numeric).reshape(batch, n_lhs), 0
+
+    if aAx is not None:
+        if Ax.ndim != 3:
+            msg = f"Ax should be 3D when vectorizing over it. Got: {Ax.shape=}."
+            raise ValueError(msg)
+        Ax = jnp.moveaxis(Ax, aAx, 0)
+        batch, n_lhs, n_vals = Ax.shape
+        numeric = jnp.broadcast_to(numeric[None], (batch, numeric.shape[0]))
+        Ax = Ax.reshape(batch * n_lhs, n_vals)
+        numeric = numeric.reshape(batch * n_lhs)
+        return prim.bind(Ai, Aj, Ax, symbolic, numeric).reshape(batch, n_lhs), 0
+
+    if anumeric is not None:
+        if numeric.ndim != 2:
+            msg = f"numeric should be 2D when vectorizing over it. Got: {numeric.shape=}."
+            raise ValueError(msg)
+        numeric = jnp.moveaxis(numeric, anumeric, 0)
+        batch, n_lhs = numeric.shape
+        Ax = jnp.broadcast_to(Ax[None], (batch, Ax.shape[0], Ax.shape[1]))
+        Ax = Ax.reshape(batch * n_lhs, Ax.shape[2])
+        numeric = numeric.reshape(batch * n_lhs)
+        return prim.bind(Ai, Aj, Ax, symbolic, numeric).reshape(batch, n_lhs), 0
+
     msg = "vmap failed. Please select an axis to vectorize over."
     raise ValueError(msg)
 

--- a/klujax.py
+++ b/klujax.py
@@ -1051,49 +1051,44 @@ def general_vmap_with_numeric(
     
     # numeric and b should batch together
     if anumeric is not None and ab is not None:
-        # Both numeric and b are batched - they should batch along the same dimension
-        if numeric.ndim != 2 or b.ndim != 3:
+        if numeric.ndim != 2 or b.ndim < 2:
             msg = (
-                "numeric and b should be 2D and 3D respectively when vectorizing "
+                "numeric should be 2D and b should be at least 2D when vectorizing "
                 f"over them simultaneously. Got: {numeric.shape=}; {b.shape=}."
             )
             raise ValueError(msg)
-        # Move batch axes to the front
         numeric = jnp.moveaxis(numeric, anumeric, 0)
         b = jnp.moveaxis(b, ab, 0)
         shape = b.shape
-        # Flatten the batch dimension with the matrix dimension
-        numeric = numeric.reshape(numeric.shape[0] * numeric.shape[1])
-        b = b.reshape(b.shape[0] * b.shape[1], b.shape[2])
+        batch = shape[0]
+        numeric = numeric.reshape(batch * numeric.shape[1])
+        if b.ndim >= 3:
+            b = b.reshape(batch * b.shape[1], *b.shape[2:])
+        # b.ndim == 2: shape is (batch, n) — pass directly, matches multi-LHS convention
         result = prim.bind(symbolic, numeric, b)
-        # Reshape back to include the batch dimension
         return result.reshape(*shape), 0
-    
+
     if anumeric is not None:
-        # Only numeric is batched
-        if numeric.ndim != 2 or b.ndim != 2:
-            msg = (
-                "numeric and b should be 2D when vectorizing over numeric. "
-                f"Got: {numeric.shape=}; {b.shape=}."
-            )
+        if numeric.ndim != 2:
+            msg = f"numeric should be 2D when vectorizing over it. Got: {numeric.shape=}."
             raise ValueError(msg)
         numeric = jnp.moveaxis(numeric, anumeric, 0)
-        # Broadcast b to match the batch dimension
-        b = jnp.broadcast_to(b[None], (numeric.shape[0], b.shape[0], b.shape[1]))
+        batch = numeric.shape[0]
+        b = jnp.broadcast_to(b[None], (batch, *b.shape))
         shape = b.shape
-        numeric = numeric.reshape(numeric.shape[0] * numeric.shape[1])
-        b = b.reshape(b.shape[0] * b.shape[1], b.shape[2])
+        numeric = numeric.reshape(batch * numeric.shape[1])
+        if b.ndim >= 3:
+            b = b.reshape(batch * b.shape[1], *b.shape[2:])
+        # b.ndim == 2: shape is (batch, n) — pass directly
         return prim.bind(symbolic, numeric, b).reshape(*shape), 0
-    
+
     if ab is not None:
-        # Only b is batched
-        if b.ndim != 3:
-            msg = f"b should be 3D when vectorizing over it. Got: {b.shape=}."
-            raise ValueError(msg)
-        b = jnp.moveaxis(b, ab, 2)
+        b = jnp.moveaxis(b, ab, -1)
         shape = b.shape
-        b = b.reshape(b.shape[0], b.shape[1] * b.shape[2])
-        return prim.bind(symbolic, numeric, b).reshape(*shape), 2
+        if b.ndim >= 3:
+            b = b.reshape(*b.shape[:-2], b.shape[-2] * b.shape[-1])
+        # b.ndim == 2: shape is (n, batch) — pass directly as multi-RHS
+        return prim.bind(symbolic, numeric, b).reshape(*shape), len(shape) - 1
     
     msg = "vmap failed. Please select an axis to vectorize over."
     raise ValueError(msg)

--- a/tests.py
+++ b/tests.py
@@ -350,6 +350,147 @@ def _is_almost_equal(arr1, arr2):
     else:
         return True
 
+def _make_ax2(Ai, Aj, Ax, *, dtype, seed=42):
+    """New Ax values with the same sparsity pattern as Ax, with a strong diagonal."""
+    Ax_raw = jax.random.normal(jax.random.PRNGKey(seed), Ax.shape, dtype=dtype)
+    # Ensure diagonal entries are large (invertible) — Ai[k]==Aj[k] marks diagonal positions
+    if Ax_raw.ndim == 1:
+        Ax_raw = Ax_raw + jnp.where(Ai == Aj, jnp.full_like(Ax_raw, 10.0), jnp.zeros_like(Ax_raw))
+    else:  # (n_lhs, n_nz) batch case
+        diag_mask = (Ai == Aj)[None, :]
+        Ax_raw = Ax_raw + jnp.where(diag_mask, jnp.full_like(Ax_raw, 10.0), jnp.zeros_like(Ax_raw))
+    return Ax_raw
+
+
+@log_test_name
+@parametrize_dtypes
+def test_refactor(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_1d(15, (n_col := 5), dtype=dtype)
+    Ax2 = _make_ax2(Ai, Aj, Ax, dtype=dtype)
+    b2 = jax.random.normal(jax.random.PRNGKey(43), b.shape, dtype=dtype)
+
+    sym = klujax.analyze(Ai, Aj, n_col)
+    num = klujax.factor(Ai, Aj, Ax, sym)
+
+    num2 = klujax.refactor(Ai, Aj, Ax2, num, sym)
+    assert isinstance(num2, klujax.KLUHandleManager)
+
+    x_sp = klujax.solve_with_numeric(num2, b2, sym)
+    A2 = jnp.zeros((n_col, n_col), dtype=dtype).at[Ai, Aj].add(Ax2)
+    x = jsp.linalg.solve(A2, b2)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_numeric(num)
+    klujax.free_symbolic(sym)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_refactor_batched(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_2d((n_lhs := 3), 15, (n_col := 5), dtype=dtype)
+    Ax2 = _make_ax2(Ai, Aj, Ax, dtype=dtype)
+    b2 = jax.random.normal(jax.random.PRNGKey(43), b.shape, dtype=dtype)
+
+    sym = klujax.analyze(Ai, Aj, n_col)
+    num = klujax.factor(Ai, Aj, Ax, sym)
+
+    num2 = klujax.refactor(Ai, Aj, Ax2, num, sym)
+    assert isinstance(num2, klujax.KLUHandleManager)
+
+    x_sp = klujax.solve_with_numeric(num2, b2, sym)
+    op_dense = jax.vmap(jsp.linalg.solve, (0, 0), 0)
+    A2 = jnp.zeros((n_lhs, n_col, n_col), dtype=dtype).at[:, Ai, Aj].add(Ax2)
+    x = op_dense(A2, b2)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_numeric(num)
+    klujax.free_symbolic(sym)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_refactor_vmap(dtype):
+    """vmap solve_with_symbol over n_rhs with shared sym used by refactor.
+
+    Tests that vmap composes correctly with the symbolic analysis after refactor,
+    and that refactor does not corrupt the symbolic object.
+    """
+    Ai, Aj, Ax, b = _get_rand_arrs_3d((n_lhs := 3), 15, (n_col := 5), 4, dtype=dtype)
+    Ax2 = _make_ax2(Ai, Aj, Ax, dtype=dtype)
+
+    sym = klujax.analyze(Ai, Aj, n_col)
+    num = klujax.factor(Ai, Aj, Ax, sym)
+    num2 = klujax.refactor(Ai, Aj, Ax2, num, sym)
+
+    # vmap solve_with_symbol over n_rhs axis (same pattern as test_3d_vmap)
+    x_sp = jax.vmap(
+        klujax.solve_with_symbol, (None, None, None, -1, None), -1
+    )(Ai, Aj, Ax2, b, sym)
+
+    A2 = jnp.zeros((n_lhs, n_col, n_col), dtype=dtype).at[:, Ai, Aj].add(Ax2)
+    x = jax.vmap(jax.vmap(jsp.linalg.solve, (0, 0), 0), (None, -1), -1)(A2, b)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_numeric(num2)
+    klujax.free_symbolic(sym)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_refactor_pmap(dtype):
+    """pmap solve_with_numeric across devices after refactor."""
+    n_dev = jax.device_count()
+    Ai, Aj, Ax, _ = _get_rand_arrs_1d(15, (n_col := 5), dtype=dtype)
+    Ax2 = _make_ax2(Ai, Aj, Ax, dtype=dtype)
+    B = jax.random.normal(jax.random.PRNGKey(77), (n_dev, n_col), dtype=dtype)
+
+    sym = klujax.analyze(Ai, Aj, n_col)
+    num = klujax.factor(Ai, Aj, Ax, sym)
+    num2 = klujax.refactor(Ai, Aj, Ax2, num, sym)
+
+    x_sp = jax.pmap(lambda b: klujax.solve_with_numeric(num2, b, sym))(B)
+
+    A2 = jnp.zeros((n_col, n_col), dtype=dtype).at[Ai, Aj].add(Ax2)
+    x = jax.vmap(lambda b: jsp.linalg.solve(A2, b))(B)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_numeric(num2)
+    klujax.free_symbolic(sym)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_refactor_grad(dtype):
+    """AD through solve_with_symbol is unaffected by refactor on the shared symbolic analysis."""
+    Ai, Aj, Ax, _ = _get_rand_arrs_1d(15, (n_col := 5), dtype=dtype)
+    Ax2 = _make_ax2(Ai, Aj, Ax, dtype=dtype)
+    b2 = jax.random.normal(jax.random.PRNGKey(43), (n_col,), dtype=dtype)
+    holomorphic = dtype in COMPLEX_DTYPES
+
+    sym = klujax.analyze(Ai, Aj, n_col)
+    num = klujax.factor(Ai, Aj, Ax, sym)
+    num2 = klujax.refactor(Ai, Aj, Ax2, num, sym)
+
+    # refactor value and solve_with_symbol value must agree
+    x_num = klujax.solve_with_numeric(num2, b2, sym)
+    x_sym = klujax.solve_with_symbol(Ai, Aj, Ax2, b2, sym)
+    _log_and_test_equality(x_num, x_sym)
+
+    # jacfwd through solve_with_symbol w.r.t. Ax: tests that sym is not corrupted by refactor
+    jac_sp = jax.jacfwd(
+        lambda ax: klujax.solve_with_symbol(Ai, Aj, ax, b2, sym),
+        holomorphic=holomorphic,
+    )(Ax2)
+    jac_dense = jax.jacfwd(
+        lambda ax: jnp.linalg.solve(jnp.zeros((n_col, n_col), dtype=dtype).at[Ai, Aj].add(ax), b2),
+        holomorphic=holomorphic,
+    )(Ax2)
+    _log_and_test_equality(jac_sp, jac_dense)
+
+    klujax.free_numeric(num2)
+    klujax.free_symbolic(sym)
+
+
 def test_solve_with_symbol_jvp():
 
     Ai = jnp.array([0, 1], dtype=jnp.int32)

--- a/tests.py
+++ b/tests.py
@@ -267,6 +267,33 @@ def test_solve_with_numeric_batched(dtype):
     klujax.free_numeric(numeric)
     klujax.free_symbolic(symbolic)
 
+
+@log_test_name
+@parametrize_dtypes
+def test_solve_with_numeric_vmap_1d_b(dtype):
+    """vmap over solve_with_numeric where b is 1D (single-system, single-RHS)."""
+    Ai, Aj, Ax, b = _get_rand_arrs_1d(15, (n_col := 5), dtype=dtype)
+    symbolic = klujax.analyze(Ai, Aj, n_col)
+
+    # Create a batch of different Ax values (different matrix values, same sparsity)
+    key = jax.random.PRNGKey(42)
+    batch = 4
+    Ax_batch = jax.random.normal(key, (batch, *Ax.shape), dtype=dtype) + 10.0
+
+    def solve_one(Ax_i):
+        num = klujax.factor(Ai, Aj, Ax_i, symbolic)
+        return klujax.solve_with_numeric(num, b, symbolic)
+
+    x_sp = jax.vmap(solve_one)(Ax_batch)
+
+    # Dense reference
+    A_batch = jnp.zeros((batch, n_col, n_col), dtype=dtype).at[:, Ai, Aj].add(Ax_batch)
+    x = jax.vmap(lambda A: jsp.linalg.solve(A, b))(A_batch)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_symbolic(symbolic)
+
+
 def _get_rand_arrs_1d(n_nz, n_col, *, dtype, seed=33):
     Axkey, Aikey, Ajkey, bkey = jax.random.split(jax.random.PRNGKey(seed), 4)
     Ai = jax.random.randint(Aikey, (n_nz,), 0, n_col, jnp.int32)


### PR DESCRIPTION
Add klujax.refactor() which re-factorizes a matrix numerically using an
existing symbolic analysis, avoiding the cost of klu_factor when the
sparsity pattern is unchanged but values have changed.