### PR TITLE
Refactor and solve

### DIFF
--- a/klujax.cpp
+++ b/klujax.cpp
@@ -140,6 +140,9 @@ struct KluTraits<double> {
     static int solve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, double* B, klu_common* Common) {
         return klu_solve(Symbolic, Numeric, d, nrhs, B, Common);
     }
+    static int tsolve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, double* B, klu_common* Common) {
+        return klu_tsolve(Symbolic, Numeric, d, nrhs, B, Common);
+    }
 };
 
 template <>
@@ -152,6 +155,10 @@ struct KluTraits<Complex> {
     }
     static int solve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, Complex* B, klu_common* Common) {
         return klu_z_solve(Symbolic, Numeric, d, nrhs, reinterpret_cast<double*>(B), Common);
+    }
+    // conj_solve=0 gives plain transpose A^T; use 1 for conjugate transpose A^H
+    static int tsolve(klu_symbolic* Symbolic, klu_numeric* Numeric, int d, int nrhs, Complex* B, klu_common* Common) {
+        return klu_z_tsolve(Symbolic, Numeric, d, nrhs, reinterpret_cast<double*>(B), 0, Common);
     }
 };
 
@@ -501,6 +508,133 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Ret<ffi::Buffer<ffi::DataType::C128>>()  // x
 );
 
+// tsolve_with_symbol: identical to solve_with_symbol_impl but uses KluTraits<T>::tsolve
+// Solves A^T x = b (transpose solve) reusing a pre-computed symbolic factorization.
+template <typename T>
+ffi::Error tsolve_with_symbol_impl(
+    const ffi::Buffer<ffi::DataType::S32>& Ai,
+    const ffi::Buffer<ffi::DataType::S32>& Aj,
+    const ffi::AnyBuffer::Dimensions& ds_Ax,
+    const ffi::AnyBuffer::Dimensions& ds_b,
+    const ffi::Buffer<ffi::DataType::U64>& symbolic,
+    const T* _Ax,
+    const T* _b,
+    T* _x) {
+    if (symbolic.element_count() != 1) return ffi::Error::InvalidArgument("symbolic must be scalar");
+    uint64_t sym_addr = *symbolic.typed_data();
+    if (sym_addr == 0) return ffi::Error::InvalidArgument("symbolic pointer is null");
+    klu_symbolic* Symbolic = reinterpret_cast<klu_symbolic*>(sym_addr);
+
+    ffi::Error err = validate_args(Ai, Aj, ds_Ax, ds_b);
+    if (err.failure()) {
+        return err;
+    }
+
+    int n_lhs = (int)ds_b[0];
+    int n_col = (int)ds_b[1];
+    int n_rhs = (int)ds_b[2];
+    int n_nz = (int)ds_Ax[1];
+    const int* _Ai = Ai.typed_data();
+    const int* _Aj = Aj.typed_data();
+
+    auto _Bk = std::make_unique<int[]>(n_nz);
+    auto _Bi = std::make_unique<int[]>(n_nz);
+    auto _Bp = std::make_unique<int[]>(n_col + 1);
+    auto _Bx = std::make_unique<T[]>(n_nz);
+
+    coo_to_csc_analyze(n_col, n_nz, _Ai, _Aj, _Bi.get(), _Bp.get(), _Bk.get());
+
+    auto _x_temp = std::make_unique<T[]>(n_lhs * n_col * n_rhs);
+    for (int m = 0; m < n_lhs; m++) {
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x_temp[m * n_rhs * n_col + p * n_col + n] = _b[m * n_col * n_rhs + n * n_rhs + p];
+            }
+        }
+    }
+
+    klu_common Common;
+    klu_defaults(&Common);
+
+    klu_numeric* Numeric;
+    for (int i = 0; i < n_lhs; i++) {
+        int m = i * n_nz;
+        int n = i * n_rhs * n_col;
+
+        for (int k = 0; k < n_nz; k++) {
+            _Bx[k] = _Ax[m + _Bk[k]];
+        }
+
+        Numeric = KluTraits<T>::factor(_Bp.get(), _Bi.get(), _Bx.get(), Symbolic, &Common);
+        if (Numeric == nullptr || Common.status < KLU_OK) {
+            return ffi::Error::InvalidArgument("klu_factor/z_factor failed (singular matrix?)");
+        }
+        // NOTE: tsolve instead of solve
+        KluTraits<T>::tsolve(Symbolic, Numeric, n_col, n_rhs, &_x_temp[n], &Common);
+        if (Common.status < KLU_OK) {
+            klu_free_numeric(&Numeric, &Common);
+            return ffi::Error::InvalidArgument("klu_tsolve/z_tsolve failed");
+        }
+        klu_free_numeric(&Numeric, &Common);
+    }
+
+    for (int m = 0; m < n_lhs; m++) {
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x[m * n_col * n_rhs + n * n_rhs + p] = _x_temp[m * n_rhs * n_col + p * n_col + n];
+            }
+        }
+    }
+
+    return ffi::Error::Success();
+}
+
+ffi::Error tsolve_with_symbol_f64(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::F64> Ax,
+    const ffi::Buffer<ffi::DataType::F64> b,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    ffi::Result<ffi::Buffer<ffi::DataType::F64>> x) {
+    return tsolve_with_symbol_impl<double>(Ai, Aj, Ax.dimensions(), b.dimensions(), symbolic,
+                                           Ax.typed_data(), b.typed_data(), x->typed_data());
+}
+
+ffi::Error tsolve_with_symbol_c128(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::C128> Ax,
+    const ffi::Buffer<ffi::DataType::C128> b,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    ffi::Result<ffi::Buffer<ffi::DataType::C128>> x) {
+    return tsolve_with_symbol_impl<Complex>(Ai, Aj, Ax.dimensions(), b.dimensions(), symbolic,
+                                            reinterpret_cast<const Complex*>(Ax.typed_data()),
+                                            reinterpret_cast<const Complex*>(b.typed_data()),
+                                            reinterpret_cast<Complex*>(x->typed_data()));
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    tsolve_with_symbol_f64_handler, tsolve_with_symbol_f64,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Ai
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Aj
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()  // Ax
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()  // b
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // symbolic
+        .Ret<ffi::Buffer<ffi::DataType::F64>>()  // x
+);
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    tsolve_with_symbol_c128_handler, tsolve_with_symbol_c128,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()   // Ai
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()   // Aj
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()  // Ax
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()  // b
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()   // symbolic
+        .Ret<ffi::Buffer<ffi::DataType::C128>>()  // x
+);
+
 template <typename T>
 ffi::Error factor_impl(
     const ffi::Buffer<ffi::DataType::S32>& Ai,
@@ -698,6 +832,166 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Ret<ffi::Buffer<ffi::DataType::U64>>()   // out_numeric (same handles, for XLA dep edge)
 );
 
+// refactor_and_solve: fused in-place refactorization followed by triangular solve.
+// Avoids allocating the CSC buffer twice and saves a JAX dispatch round-trip.
+// Returns two outputs: x (the solution) and out_numeric (same pointers as input numeric,
+// threaded through so XLA sees the dependency edge: refactor → solve → next-op).
+template <typename T>
+ffi::Error refactor_and_solve_impl(
+    const ffi::Buffer<ffi::DataType::S32>& Ai,
+    const ffi::Buffer<ffi::DataType::S32>& Aj,
+    const ffi::AnyBuffer::Dimensions& ds_Ax,
+    const ffi::AnyBuffer::Dimensions& ds_b,
+    const ffi::Buffer<ffi::DataType::U64>& symbolic,
+    const ffi::Buffer<ffi::DataType::U64>& numeric,
+    const T* _Ax,
+    const T* _b,
+    T* _x,
+    uint64_t* _out_numeric) {
+    if (symbolic.element_count() != 1) return ffi::Error::InvalidArgument("symbolic must be scalar");
+    uint64_t sym_addr = *symbolic.typed_data();
+    if (sym_addr == 0) return ffi::Error::InvalidArgument("symbolic pointer is null");
+    klu_symbolic* Symbolic = reinterpret_cast<klu_symbolic*>(sym_addr);
+
+    int n_lhs_ax = (int)ds_Ax[0];
+    int n_nz = (int)ds_Ax[1];
+    int n_col = Symbolic->n;
+
+    if (Ai.dimensions().size() != 1 || Aj.dimensions().size() != 1) return ffi::Error::InvalidArgument("Ai/Aj must be 1D");
+    if (Ai.dimensions()[0] != n_nz || Aj.dimensions()[0] != n_nz) return ffi::Error::InvalidArgument("Ai/Aj size mismatch with Ax");
+    if ((int)numeric.element_count() != n_lhs_ax) return ffi::Error::InvalidArgument("numeric array size must match n_lhs");
+
+    // Validate b dimensions: must be 3D (n_lhs, n_col, n_rhs)
+    if (ds_b.size() != 3) return ffi::Error::InvalidArgument("b must be 3D (n_lhs, n_col, n_rhs)");
+    int n_lhs_b = (int)ds_b[0];
+    int n_rhs   = (int)ds_b[2];
+
+    if (n_lhs_ax != n_lhs_b) return ffi::Error::InvalidArgument("n_lhs mismatch between Ax and b");
+
+    int n_lhs = n_lhs_ax;
+
+    const int* _Ai = Ai.typed_data();
+    const int* _Aj = Aj.typed_data();
+    const uint64_t* _numeric = numeric.typed_data();
+
+    auto _Bk = std::make_unique<int[]>(n_nz);
+    auto _Bi = std::make_unique<int[]>(n_nz);
+    auto _Bp = std::make_unique<int[]>(n_col + 1);
+    auto _Bx = std::make_unique<T[]>(n_nz);
+
+    coo_to_csc_analyze(n_col, n_nz, _Ai, _Aj, _Bi.get(), _Bp.get(), _Bk.get());
+
+    // Transpose b into col-major temp buffer for KLU
+    auto _x_temp = std::make_unique<T[]>(n_lhs * n_col * n_rhs);
+    for (int m = 0; m < n_lhs; m++) {
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x_temp[m * n_rhs * n_col + p * n_col + n] = _b[m * n_col * n_rhs + n * n_rhs + p];
+            }
+        }
+    }
+
+    klu_common Common;
+    klu_defaults(&Common);
+
+    for (int i = 0; i < n_lhs; i++) {
+        uint64_t num_addr = _numeric[i];
+        if (num_addr == 0) return ffi::Error::InvalidArgument("numeric pointer is null");
+        klu_numeric* Numeric = reinterpret_cast<klu_numeric*>(num_addr);
+
+        int m = i * n_nz;
+        int n = i * n_rhs * n_col;
+
+        // Convert COO Ax to CSC Bx
+        for (int k = 0; k < n_nz; k++) {
+            _Bx[k] = _Ax[m + _Bk[k]];
+        }
+
+        // Refactor in-place (reuses pivots from original factor call)
+        int status = KluTraits<T>::refactor(_Bp.get(), _Bi.get(), _Bx.get(), Symbolic, Numeric, &Common);
+        if (!status || Common.status < KLU_OK) {
+            return ffi::Error::InvalidArgument("klu_refactor/z_refactor failed (singular matrix?)");
+        }
+
+        // Solve immediately using the freshly refactored numeric
+        KluTraits<T>::solve(Symbolic, Numeric, n_col, n_rhs, &_x_temp[n], &Common);
+        if (Common.status < KLU_OK) {
+            return ffi::Error::InvalidArgument("klu_solve/z_solve failed");
+        }
+
+        // Pass through the same numeric pointer for the XLA dependency edge
+        _out_numeric[i] = num_addr;
+    }
+
+    // Transpose result back to row-major for JAX
+    for (int m = 0; m < n_lhs; m++) {
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x[m * n_col * n_rhs + n * n_rhs + p] = _x_temp[m * n_rhs * n_col + p * n_col + n];
+            }
+        }
+    }
+
+    return ffi::Error::Success();
+}
+
+ffi::Error refactor_and_solve_f64(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::F64> Ax,
+    const ffi::Buffer<ffi::DataType::F64> b,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    ffi::Result<ffi::Buffer<ffi::DataType::F64>> x,
+    ffi::Result<ffi::Buffer<ffi::DataType::U64>> out_numeric) {
+    return refactor_and_solve_impl<double>(
+        Ai, Aj, Ax.dimensions(), b.dimensions(), symbolic, numeric,
+        Ax.typed_data(), b.typed_data(), x->typed_data(), out_numeric->typed_data());
+}
+
+ffi::Error refactor_and_solve_c128(
+    const ffi::Buffer<ffi::DataType::S32> Ai,
+    const ffi::Buffer<ffi::DataType::S32> Aj,
+    const ffi::Buffer<ffi::DataType::C128> Ax,
+    const ffi::Buffer<ffi::DataType::C128> b,
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    ffi::Result<ffi::Buffer<ffi::DataType::C128>> x,
+    ffi::Result<ffi::Buffer<ffi::DataType::U64>> out_numeric) {
+    return refactor_and_solve_impl<Complex>(
+        Ai, Aj, Ax.dimensions(), b.dimensions(), symbolic, numeric,
+        reinterpret_cast<const Complex*>(Ax.typed_data()),
+        reinterpret_cast<const Complex*>(b.typed_data()),
+        reinterpret_cast<Complex*>(x->typed_data()),
+        out_numeric->typed_data());
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    refactor_and_solve_f64_handler, refactor_and_solve_f64,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Ai
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()  // Aj
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()  // Ax
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()  // b
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // symbolic
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // numeric (input handles)
+        .Ret<ffi::Buffer<ffi::DataType::F64>>()  // x (solution)
+        .Ret<ffi::Buffer<ffi::DataType::U64>>()  // out_numeric (same handles, for XLA dep edge)
+);
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    refactor_and_solve_c128_handler, refactor_and_solve_c128,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()   // Ai
+        .Arg<ffi::Buffer<ffi::DataType::S32>>()   // Aj
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()  // Ax
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()  // b
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()   // symbolic
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()   // numeric (input handles)
+        .Ret<ffi::Buffer<ffi::DataType::C128>>()  // x (solution)
+        .Ret<ffi::Buffer<ffi::DataType::U64>>()   // out_numeric (same handles, for XLA dep edge)
+);
+
 template <typename T>
 ffi::Error solve_with_numeric_impl(
     const ffi::AnyBuffer::Dimensions& ds_b,
@@ -842,6 +1136,141 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Arg<ffi::Buffer<ffi::DataType::C128>>()
         .Ret<ffi::Buffer<ffi::DataType::C128>>());
 
+// tsolve_with_numeric: identical to solve_with_numeric_impl but uses KluTraits<T>::tsolve.
+// Solves A^T x = b using a pre-computed numeric factorization.
+template <typename T>
+ffi::Error tsolve_with_numeric_impl(
+    const ffi::AnyBuffer::Dimensions& ds_b,
+    const ffi::AnyBuffer::Dimensions& ds_x,
+    const ffi::Buffer<ffi::DataType::U64>& symbolic,
+    const ffi::Buffer<ffi::DataType::U64>& numeric,
+    const T* _b,
+    T* _x) {
+
+    if (symbolic.element_count() != 1) return ffi::Error::InvalidArgument("symbolic must be scalar");
+    uint64_t sym_addr = *symbolic.typed_data();
+    if (sym_addr == 0) return ffi::Error::InvalidArgument("symbolic pointer is null");
+    klu_symbolic* Symbolic = reinterpret_cast<klu_symbolic*>(sym_addr);
+
+    int n_numeric = numeric.element_count();
+    const uint64_t* _numeric = numeric.typed_data();
+
+    int d_b = ds_b.size();
+    int n_lhs_b, n_col, n_rhs;
+
+    if (d_b == 1) {
+        n_lhs_b = 1;
+        n_col = ds_b[0];
+        n_rhs = 1;
+    } else if (d_b == 2) {
+        if (n_numeric > 1 && (int)ds_b[0] == n_numeric) {
+            n_lhs_b = ds_b[0];
+            n_col = ds_b[1];
+            n_rhs = 1;
+        } else {
+            n_lhs_b = 1;
+            n_col = ds_b[0];
+            n_rhs = ds_b[1];
+        }
+    } else if (d_b == 3) {
+        n_lhs_b = ds_b[0];
+        n_col = ds_b[1];
+        n_rhs = ds_b[2];
+    } else {
+        return ffi::Error::InvalidArgument("b must be 1D, 2D, or 3D");
+    }
+
+    bool broadcast_numeric = (n_numeric == 1);
+    bool broadcast_b = (n_lhs_b == 1);
+
+    int n_lhs;
+    if (!broadcast_numeric && !broadcast_b) {
+        if (n_numeric != n_lhs_b) return ffi::Error::InvalidArgument("numeric and b batch size mismatch");
+        n_lhs = n_numeric;
+    } else if (!broadcast_numeric) {
+        n_lhs = n_numeric;
+    } else if (!broadcast_b) {
+        n_lhs = n_lhs_b;
+    } else {
+        n_lhs = 1;
+    }
+
+    if (ds_x.size() != d_b) return ffi::Error::InvalidArgument("output dimensions don't match input");
+
+    auto _x_temp = std::make_unique<T[]>(n_lhs * n_col * n_rhs);
+
+    for (int m = 0; m < n_lhs; m++) {
+        int m_b = broadcast_b ? 0 : m;
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x_temp[m * n_rhs * n_col + p * n_col + n] = _b[m_b * n_col * n_rhs + n * n_rhs + p];
+            }
+        }
+    }
+
+    klu_common Common;
+    klu_defaults(&Common);
+
+    for (int i = 0; i < n_lhs; i++) {
+        int n = i * n_rhs * n_col;
+        uint64_t num_addr = broadcast_numeric ? _numeric[0] : _numeric[i];
+        if (num_addr == 0) return ffi::Error::InvalidArgument("numeric pointer is null");
+
+        klu_numeric* Numeric = reinterpret_cast<klu_numeric*>(num_addr);
+        // NOTE: tsolve instead of solve
+        KluTraits<T>::tsolve(Symbolic, Numeric, n_col, n_rhs, &_x_temp[n], &Common);
+
+        if (Common.status < KLU_OK) {
+            return ffi::Error::InvalidArgument("klu_tsolve/z_tsolve failed");
+        }
+    }
+
+    for (int m = 0; m < n_lhs; m++) {
+        for (int n = 0; n < n_col; n++) {
+            for (int p = 0; p < n_rhs; p++) {
+                _x[m * n_col * n_rhs + n * n_rhs + p] = _x_temp[m * n_rhs * n_col + p * n_col + n];
+            }
+        }
+    }
+    return ffi::Error::Success();
+}
+
+ffi::Error tsolve_with_numeric_f64(
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    const ffi::Buffer<ffi::DataType::F64> b,
+    ffi::Result<ffi::Buffer<ffi::DataType::F64>> x) {
+    return tsolve_with_numeric_impl<double>(b.dimensions(), x->dimensions(), symbolic, numeric, b.typed_data(), x->typed_data());
+}
+
+ffi::Error tsolve_with_numeric_c128(
+    const ffi::Buffer<ffi::DataType::U64> symbolic,
+    const ffi::Buffer<ffi::DataType::U64> numeric,
+    const ffi::Buffer<ffi::DataType::C128> b,
+    ffi::Result<ffi::Buffer<ffi::DataType::C128>> x) {
+    return tsolve_with_numeric_impl<Complex>(b.dimensions(), x->dimensions(), symbolic, numeric,
+                                             reinterpret_cast<const Complex*>(b.typed_data()),
+                                             reinterpret_cast<Complex*>(x->typed_data()));
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    tsolve_with_numeric_f64_handler, tsolve_with_numeric_f64,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // symbolic
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()  // numeric
+        .Arg<ffi::Buffer<ffi::DataType::F64>>()  // b
+        .Ret<ffi::Buffer<ffi::DataType::F64>>()  // x
+);
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    tsolve_with_numeric_c128_handler, tsolve_with_numeric_c128,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()   // symbolic
+        .Arg<ffi::Buffer<ffi::DataType::U64>>()   // numeric
+        .Arg<ffi::Buffer<ffi::DataType::C128>>()  // b
+        .Ret<ffi::Buffer<ffi::DataType::C128>>()  // x
+);
+
 ffi::Error free_numeric(
     const ffi::Buffer<ffi::DataType::U64> numeric,
     ffi::Result<ffi::Buffer<ffi::DataType::S32>> status) {
@@ -968,6 +1397,10 @@ PYBIND11_MODULE(klujax_cpp, m) {
           []() { return py::capsule((void*)&solve_with_symbol_f64_handler); });
     m.def("solve_with_symbol_c128",
           []() { return py::capsule((void*)&solve_with_symbol_c128_handler); });
+    m.def("tsolve_with_symbol_f64",
+          []() { return py::capsule((void*)&tsolve_with_symbol_f64_handler); });
+    m.def("tsolve_with_symbol_c128",
+          []() { return py::capsule((void*)&tsolve_with_symbol_c128_handler); });
     m.def("factor_f64",
           []() { return py::capsule((void*)&factor_f64_handler); });
     m.def("factor_c128",
@@ -976,6 +1409,10 @@ PYBIND11_MODULE(klujax_cpp, m) {
           []() { return py::capsule((void*)&solve_with_numeric_f64_handler); });
     m.def("solve_with_numeric_c128",
           []() { return py::capsule((void*)&solve_with_numeric_c128_handler); });
+    m.def("tsolve_with_numeric_f64",
+          []() { return py::capsule((void*)&tsolve_with_numeric_f64_handler); });
+    m.def("tsolve_with_numeric_c128",
+          []() { return py::capsule((void*)&tsolve_with_numeric_c128_handler); });
     m.def("free_numeric",
           []() { return py::capsule((void*)&free_numeric_handler); });
     m.def("analyze",
@@ -986,4 +1423,8 @@ PYBIND11_MODULE(klujax_cpp, m) {
           []() { return py::capsule((void*)&refactor_f64_handler); });
     m.def("refactor_c128",
           []() { return py::capsule((void*)&refactor_c128_handler); });
+    m.def("refactor_and_solve_f64",
+          []() { return py::capsule((void*)&refactor_and_solve_f64_handler); });
+    m.def("refactor_and_solve_c128",
+          []() { return py::capsule((void*)&refactor_and_solve_c128_handler); });
 }

--- a/klujax.cpp
+++ b/klujax.cpp
@@ -864,7 +864,7 @@ ffi::Error refactor_and_solve_impl(
     // Validate b dimensions: must be 3D (n_lhs, n_col, n_rhs)
     if (ds_b.size() != 3) return ffi::Error::InvalidArgument("b must be 3D (n_lhs, n_col, n_rhs)");
     int n_lhs_b = (int)ds_b[0];
-    int n_rhs   = (int)ds_b[2];
+    int n_rhs = (int)ds_b[2];
 
     if (n_lhs_ax != n_lhs_b) return ffi::Error::InvalidArgument("n_lhs mismatch between Ax and b");
 
@@ -1146,7 +1146,6 @@ ffi::Error tsolve_with_numeric_impl(
     const ffi::Buffer<ffi::DataType::U64>& numeric,
     const T* _b,
     T* _x) {
-
     if (symbolic.element_count() != 1) return ffi::Error::InvalidArgument("symbolic must be scalar");
     uint64_t sym_addr = *symbolic.typed_data();
     if (sym_addr == 0) return ffi::Error::InvalidArgument("symbolic pointer is null");

--- a/klujax.py
+++ b/klujax.py
@@ -394,22 +394,28 @@ def solve_with_symbol(
 
 
 @jax.jit
-def _tsolve_with_symbol_jit(Ai: Array, Aj: Array, Ax: Array, b: Array, sym_h: Array) -> Array:
+def _tsolve_with_symbol_jit(
+    Ai: Array, Aj: Array, Ax: Array, b: Array, sym_h: Array
+) -> Array:
     Ai, Aj, Ax, b, out_shape = validate_numeric_solve(Ai, Aj, Ax, b)
 
     is_complex = any(x.dtype in COMPLEX_DTYPES for x in (Ax, b))
     prim = tsolve_with_symbol_c128 if is_complex else tsolve_with_symbol_f64
 
     x = prim.bind(
-        Ai, Aj,
+        Ai,
+        Aj,
         Ax.astype(jnp.complex128 if is_complex else jnp.float64),
         b.astype(jnp.complex128 if is_complex else jnp.float64),
-        sym_h.astype(jnp.uint64)
+        sym_h.astype(jnp.uint64),
     )
 
     return x.reshape(*out_shape)
 
-def tsolve_with_symbol(Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Union[KLUHandleManager, Array]) -> Array:
+
+def tsolve_with_symbol(
+    Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: KLUHandleManager | Array
+) -> Array:
     """Solve A^T x=b (transpose solve) using a pre-computed symbolic analysis.
 
     Factors A numerically, then solves the transposed system using klu_tsolve.
@@ -432,6 +438,7 @@ def tsolve_with_symbol(Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Unio
     """
     handle = getattr(symbolic, "handle", symbolic)
     return _tsolve_with_symbol_jit(Ai, Aj, Ax, b, handle)
+
 
 @jax.jit
 def _factor_jit(Ai: Array, Aj: Array, Ax: Array, sym_h: Array) -> Array:
@@ -538,12 +545,22 @@ def solve_with_numeric(
         free_numeric(numeric, dependency=result)
     return result
 
+
 @jax.jit
 def _tsolve_with_numeric_jit(num_h: Array, b: Array, sym_h: Array) -> Array:
-    prim = tsolve_with_numeric_c128 if b.dtype in COMPLEX_DTYPES else tsolve_with_numeric_f64
+    prim = (
+        tsolve_with_numeric_c128
+        if b.dtype in COMPLEX_DTYPES
+        else tsolve_with_numeric_f64
+    )
     return prim.bind(sym_h.astype(jnp.uint64), num_h.astype(jnp.uint64), b)
 
-def tsolve_with_numeric(numeric: Union[KLUHandleManager, Array], b: Array, symbolic: Union[KLUHandleManager, Array]) -> Array:
+
+def tsolve_with_numeric(
+    numeric: KLUHandleManager | Array,
+    b: Array,
+    symbolic: KLUHandleManager | Array,
+) -> Array:
     """Solve A^T x=b (transpose solve) using a pre-computed numeric factorization.
 
     Uses klu_tsolve internally. The numeric factorization must have been computed
@@ -568,33 +585,38 @@ def tsolve_with_numeric(numeric: Union[KLUHandleManager, Array], b: Array, symbo
         free_numeric(numeric, dependency=result)
     return result
 
+
 @jax.jit
-def _refactor_and_solve_jit(Ai: Array, Aj: Array, Ax: Array, b: Array, sym_h: Array, num_h: Array) -> Tuple[Array, Array]:
-    # Use validate_numeric_solve to standardize shapes and capture the expected out_shape
+def _refactor_and_solve_jit(
+    Ai: Array, Aj: Array, Ax: Array, b: Array, sym_h: Array, num_h: Array
+) -> tuple[Array, Array]:
+    # Use validate_numeric_solve to standardize shapes and get the expected out_shape
     Ai, Aj, Ax, b, out_shape = validate_numeric_solve(Ai, Aj, Ax, b)
-    
+
     is_complex = any(x.dtype in COMPLEX_DTYPES for x in (Ax, b))
     prim = refactor_and_solve_c128 if is_complex else refactor_and_solve_f64
-    
+
     x, out_num = prim.bind(
-        Ai, Aj,
+        Ai,
+        Aj,
         Ax.astype(jnp.complex128 if is_complex else jnp.float64),
         b.astype(jnp.complex128 if is_complex else jnp.float64),
         sym_h.astype(jnp.uint64),
         num_h.astype(jnp.uint64),
     )
-    
+
     # Reshape x back to the original dimensions of b
     return x.reshape(*out_shape), out_num
+
 
 def refactor_and_solve(
     Ai: Array,
     Aj: Array,
     Ax: Array,
     b: Array,
-    numeric: Union[KLUHandleManager, Array],
-    symbolic: Union[KLUHandleManager, Array],
-) -> Tuple[Array, KLUHandleManager]:
+    numeric: KLUHandleManager | Array,
+    symbolic: KLUHandleManager | Array,
+) -> tuple[Array, KLUHandleManager]:
     """Fused in-place refactorization followed by triangular solve.
 
     Equivalent to calling refactor() then solve_with_numeric(), but executes as a
@@ -611,7 +633,8 @@ def refactor_and_solve(
         Aj: [n_nz; int32]: the column indices of the sparse matrix A
         Ax: [n_lhs? x n_nz; float64|complex128]: the values of the sparse matrix A
         b:  [n_lhs? x n_col x n_rhs?; float64|complex128]: the right-hand side
-        numeric: [KLUHandleManager|Array]: existing numeric factorization (modified in-place)
+        numeric: [KLUHandleManager|Array]: existing numeric factorization
+        (modified in-place)
         symbolic: [KLUHandleManager|Array]: the symbolic analysis object or handle
 
     Returns:
@@ -651,7 +674,7 @@ refactor_and_solve_c128 = jax.extend.core.Primitive("refactor_and_solve_c128")
 refactor_and_solve_f64.multiple_results = True
 refactor_and_solve_c128.multiple_results = True
 
-# Implementations =====================================================================
+# Implementations ========================================================
 
 
 @dot_f64.def_impl
@@ -689,12 +712,16 @@ def solve_with_symbol_c128_impl(
 
 
 @tsolve_with_symbol_f64.def_impl
-def tsolve_with_symbol_f64_impl(Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Array) -> Array:
+def tsolve_with_symbol_f64_impl(
+    Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Array
+) -> Array:
     return general_impl("tsolve_with_symbol_f64", Ai, Aj, Ax, b, symbolic)
 
 
 @tsolve_with_symbol_c128.def_impl
-def tsolve_with_symbol_c128_impl(Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Array) -> Array:
+def tsolve_with_symbol_c128_impl(
+    Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Array
+) -> Array:
     return general_impl("tsolve_with_symbol_c128", Ai, Aj, Ax, b, symbolic)
 
 
@@ -746,31 +773,45 @@ def solve_with_numeric_c128_impl(symbolic, numeric, b):
     )
     return call(symbolic, numeric, b)
 
+
 @tsolve_with_numeric_f64.def_impl
 def tsolve_with_numeric_f64_impl(symbolic, numeric, b):
-    call = jax.ffi.ffi_call("tsolve_with_numeric_f64", jax.ShapeDtypeStruct(b.shape, b.dtype))
+    call = jax.ffi.ffi_call(
+        "tsolve_with_numeric_f64", jax.ShapeDtypeStruct(b.shape, b.dtype)
+    )
     return call(symbolic, numeric, b)
+
 
 @tsolve_with_numeric_c128.def_impl
 def tsolve_with_numeric_c128_impl(symbolic, numeric, b):
-    call = jax.ffi.ffi_call("tsolve_with_numeric_c128", jax.ShapeDtypeStruct(b.shape, b.dtype))
+    call = jax.ffi.ffi_call(
+        "tsolve_with_numeric_c128", jax.ShapeDtypeStruct(b.shape, b.dtype)
+    )
     return call(symbolic, numeric, b)
+
 
 @refactor_and_solve_f64.def_impl
 def refactor_and_solve_f64_impl(Ai, Aj, Ax, b, symbolic, numeric):
     n_lhs = Ax.shape[0]
     call = jax.ffi.ffi_call(
         "refactor_and_solve_f64",
-        (jax.ShapeDtypeStruct(b.shape, b.dtype), jax.ShapeDtypeStruct((n_lhs,), jnp.uint64)),
+        (
+            jax.ShapeDtypeStruct(b.shape, b.dtype),
+            jax.ShapeDtypeStruct((n_lhs,), jnp.uint64),
+        ),
     )
     return call(Ai, Aj, Ax, b, symbolic, numeric)
+
 
 @refactor_and_solve_c128.def_impl
 def refactor_and_solve_c128_impl(Ai, Aj, Ax, b, symbolic, numeric):
     n_lhs = Ax.shape[0]
     call = jax.ffi.ffi_call(
         "refactor_and_solve_c128",
-        (jax.ShapeDtypeStruct(b.shape, b.dtype), jax.ShapeDtypeStruct((n_lhs,), jnp.uint64)),
+        (
+            jax.ShapeDtypeStruct(b.shape, b.dtype),
+            jax.ShapeDtypeStruct((n_lhs,), jnp.uint64),
+        ),
     )
     return call(Ai, Aj, Ax, b, symbolic, numeric)
 
@@ -863,7 +904,9 @@ jax.ffi.register_ffi_target(
     platform="cpu",
 )
 
-tsolve_with_symbol_f64_low = mlir.lower_fun(tsolve_with_symbol_f64_impl, multiple_results=False)
+tsolve_with_symbol_f64_low = mlir.lower_fun(
+    tsolve_with_symbol_f64_impl, multiple_results=False
+)
 mlir.register_lowering(tsolve_with_symbol_f64, tsolve_with_symbol_f64_low)
 
 jax.ffi.register_ffi_target(
@@ -872,7 +915,9 @@ jax.ffi.register_ffi_target(
     platform="cpu",
 )
 
-tsolve_with_symbol_c128_low = mlir.lower_fun(tsolve_with_symbol_c128_impl, multiple_results=False)
+tsolve_with_symbol_c128_low = mlir.lower_fun(
+    tsolve_with_symbol_c128_impl, multiple_results=False
+)
 mlir.register_lowering(tsolve_with_symbol_c128, tsolve_with_symbol_c128_low)
 
 jax.ffi.register_ffi_target(
@@ -937,20 +982,36 @@ solve_with_numeric_c128_low = mlir.lower_fun(
 )
 mlir.register_lowering(solve_with_numeric_c128, solve_with_numeric_c128_low)
 
-jax.ffi.register_ffi_target("tsolve_with_numeric_f64", klujax_cpp.tsolve_with_numeric_f64(), platform="cpu")
-tsolve_with_numeric_f64_low = mlir.lower_fun(tsolve_with_numeric_f64_impl, multiple_results=False)
+jax.ffi.register_ffi_target(
+    "tsolve_with_numeric_f64", klujax_cpp.tsolve_with_numeric_f64(), platform="cpu"
+)
+tsolve_with_numeric_f64_low = mlir.lower_fun(
+    tsolve_with_numeric_f64_impl, multiple_results=False
+)
 mlir.register_lowering(tsolve_with_numeric_f64, tsolve_with_numeric_f64_low)
 
-jax.ffi.register_ffi_target("tsolve_with_numeric_c128", klujax_cpp.tsolve_with_numeric_c128(), platform="cpu")
-tsolve_with_numeric_c128_low = mlir.lower_fun(tsolve_with_numeric_c128_impl, multiple_results=False)
+jax.ffi.register_ffi_target(
+    "tsolve_with_numeric_c128", klujax_cpp.tsolve_with_numeric_c128(), platform="cpu"
+)
+tsolve_with_numeric_c128_low = mlir.lower_fun(
+    tsolve_with_numeric_c128_impl, multiple_results=False
+)
 mlir.register_lowering(tsolve_with_numeric_c128, tsolve_with_numeric_c128_low)
 
-jax.ffi.register_ffi_target("refactor_and_solve_f64", klujax_cpp.refactor_and_solve_f64(), platform="cpu")
-refactor_and_solve_f64_low = mlir.lower_fun(refactor_and_solve_f64_impl, multiple_results=True)
+jax.ffi.register_ffi_target(
+    "refactor_and_solve_f64", klujax_cpp.refactor_and_solve_f64(), platform="cpu"
+)
+refactor_and_solve_f64_low = mlir.lower_fun(
+    refactor_and_solve_f64_impl, multiple_results=True
+)
 mlir.register_lowering(refactor_and_solve_f64, refactor_and_solve_f64_low)
 
-jax.ffi.register_ffi_target("refactor_and_solve_c128", klujax_cpp.refactor_and_solve_c128(), platform="cpu")
-refactor_and_solve_c128_low = mlir.lower_fun(refactor_and_solve_c128_impl, multiple_results=True)
+jax.ffi.register_ffi_target(
+    "refactor_and_solve_c128", klujax_cpp.refactor_and_solve_c128(), platform="cpu"
+)
+refactor_and_solve_c128_low = mlir.lower_fun(
+    refactor_and_solve_c128_impl, multiple_results=True
+)
 mlir.register_lowering(refactor_and_solve_c128, refactor_and_solve_c128_low)
 
 free_numeric_low = mlir.lower_fun(free_numeric_impl, multiple_results=False)
@@ -1003,6 +1064,7 @@ def refactor_abstract_eval(Ai, Aj, Ax, symbolic, numeric):
 def solve_with_numeric_abstract_eval(symbolic, numeric, b):
     # Output has same shape as input b
     return ShapedArray(b.shape, b.dtype)
+
 
 @refactor_and_solve_f64.def_abstract_eval
 @refactor_and_solve_c128.def_abstract_eval
@@ -1163,7 +1225,9 @@ def tsolve_with_symbol_f64_vmap(
     vector_arg_values: tuple[Array, Array, Array, Array, Array],
     batch_axes: tuple[int | None, int | None, int | None, int | None, int | None],
 ) -> tuple[Array, int]:
-    return general_vmap_with_symbol(tsolve_with_symbol_f64, vector_arg_values, batch_axes)
+    return general_vmap_with_symbol(
+        tsolve_with_symbol_f64, vector_arg_values, batch_axes
+    )
 
 
 batching.primitive_batchers[tsolve_with_symbol_f64] = tsolve_with_symbol_f64_vmap
@@ -1173,7 +1237,9 @@ def tsolve_with_symbol_c128_vmap(
     vector_arg_values: tuple[Array, Array, Array, Array, Array],
     batch_axes: tuple[int | None, int | None, int | None, int | None, int | None],
 ) -> tuple[Array, int]:
-    return general_vmap_with_symbol(tsolve_with_symbol_c128, vector_arg_values, batch_axes)
+    return general_vmap_with_symbol(
+        tsolve_with_symbol_c128, vector_arg_values, batch_axes
+    )
 
 
 batching.primitive_batchers[tsolve_with_symbol_c128] = tsolve_with_symbol_c128_vmap
@@ -1207,7 +1273,9 @@ def tsolve_with_numeric_f64_vmap(
     vector_arg_values: tuple[Array, Array, Array],
     batch_axes: tuple[int | None, int | None, int | None],
 ) -> tuple[Array, int]:
-    return general_vmap_with_numeric(tsolve_with_numeric_f64, vector_arg_values, batch_axes)
+    return general_vmap_with_numeric(
+        tsolve_with_numeric_f64, vector_arg_values, batch_axes
+    )
 
 
 batching.primitive_batchers[tsolve_with_numeric_f64] = tsolve_with_numeric_f64_vmap
@@ -1217,7 +1285,9 @@ def tsolve_with_numeric_c128_vmap(
     vector_arg_values: tuple[Array, Array, Array],
     batch_axes: tuple[int | None, int | None, int | None],
 ) -> tuple[Array, int]:
-    return general_vmap_with_numeric(tsolve_with_numeric_c128, vector_arg_values, batch_axes)
+    return general_vmap_with_numeric(
+        tsolve_with_numeric_c128, vector_arg_values, batch_axes
+    )
 
 
 batching.primitive_batchers[tsolve_with_numeric_c128] = tsolve_with_numeric_c128_vmap

--- a/klujax.py
+++ b/klujax.py
@@ -1029,6 +1029,8 @@ mlir.register_lowering(free_symbolic_p, free_symbolic_low)
 @solve_c128.def_abstract_eval
 @solve_with_symbol_f64.def_abstract_eval
 @solve_with_symbol_c128.def_abstract_eval
+@tsolve_with_symbol_f64.def_abstract_eval
+@tsolve_with_symbol_c128.def_abstract_eval
 def general_abstract_eval(
     Ai: Array, Aj: Array, Ax: Array, b: Array, *args: Array
 ) -> ShapedArray:
@@ -1059,6 +1061,8 @@ def refactor_abstract_eval(Ai, Aj, Ax, symbolic, numeric):
 
 @solve_with_numeric_f64.def_abstract_eval
 @solve_with_numeric_c128.def_abstract_eval
+@tsolve_with_numeric_f64.def_abstract_eval
+@tsolve_with_numeric_c128.def_abstract_eval
 @tsolve_with_numeric_f64.def_abstract_eval
 @tsolve_with_numeric_c128.def_abstract_eval
 def solve_with_numeric_abstract_eval(symbolic, numeric, b):

--- a/klujax.py
+++ b/klujax.py
@@ -1916,31 +1916,27 @@ def solve_with_symbol_transpose(
     b: Array,
     symbolic: Array,
 ) -> tuple[Array, Array, Array, Array, None]:
-    """Compute the transpose of solve_with_symbol.
+    if ad.is_undefined_primal(Ai) or ad.is_undefined_primal(Aj):
+        msg = "Sparse indices Ai and Aj should not require gradients."
+        raise ValueError(msg)
 
-    Note:
-        For the reverse pass (A.T), we cannot reuse the 'symbolic' handle because
-        it describes A, not A.T. Therefore, we fallback to the standard solve_transpose
-        logic which effectively treats it like a fresh solve.
+    # Pick the right tsolve primitive
+    if solve_prim is solve_with_symbol_f64:
+        tsolve_prim = tsolve_with_symbol_f64
+    else:
+        tsolve_prim = tsolve_with_symbol_c128
 
-    Args:
-        solve_prim: [Primitive]: the primitive to transpose
-        ct: [Array]: the cotangent vector
-        Ai: [n_nz; int32]: the row indices of the sparse matrix A
-        Aj: [n_nz; int32]: the column indices of the sparse matrix A
-        Ax: [n_lhs? x n_nz; float64|complex128]: the values of the sparse matrix A
-        b:  [n_lhs? x n_col x n_rhs?; float64|complex128]: the target vector
-        symbolic: [Array]: the symbolic analysis handle
+    if ad.is_undefined_primal(b):
+        # FAST PATH: Backpropagate through b using the reused handle!
+        b_bar = tsolve_prim.bind(Ai, Aj, Ax, ct, symbolic)
+        return Ai, Aj, Ax, b_bar, None
 
-    Returns:
-        tangents: tuple of tangents for (Ai, Aj, Ax, b, symbolic)
+    if ad.is_undefined_primal(Ax):
+        Ax_bar = -(ct * tsolve_prim.bind(Ai, Aj, Ax, b, symbolic)).sum(-1)
+        return Ai, Aj, Ax_bar, b, None
 
-    """
-    base_solve = solve_f64 if solve_prim is solve_with_symbol_f64 else solve_c128
-
-    t_Ai, t_Aj, t_Ax, t_b = solve_transpose(base_solve, ct, Ai, Aj, Ax, b)
-
-    return t_Ai, t_Aj, t_Ax, t_b, None
+    msg = "No undefined primals in transpose."
+    raise ValueError(msg)
 
 
 def solve_with_symbol_f64_transpose(ct, Ai, Aj, Ax, b, symbolic):

--- a/klujax.py
+++ b/klujax.py
@@ -1955,3 +1955,98 @@ def solve_with_symbol_c128_transpose(ct, Ai, Aj, Ax, b, symbolic):
 
 
 ad.primitive_transposes[solve_with_symbol_c128] = solve_with_symbol_c128_transpose
+
+
+# Differentiation rules for solve_with_numeric ================================
+
+
+def solve_with_numeric_value_and_jvp(
+    prim_solve: jax.extend.core.Primitive,
+    arg_values: tuple[Array, Array, Array],
+    arg_tangents: tuple[Any, Any, Any],
+) -> tuple[Array, Array]:
+    """Jacobian-vector product rule for `solve_with_numeric`.
+
+    Since the matrix values are baked into the numeric handle, we only track
+    gradients with respect to `b`. The rule is simply: dx = A^-1 * db.
+    """
+    symbolic, numeric, b = arg_values
+    _, _, t_b = arg_tangents
+
+    x = prim_solve.bind(symbolic, numeric, b)
+
+    if isinstance(t_b, ad.Zero):
+        dx = jnp.zeros_like(x)
+    else:
+        dx = prim_solve.bind(symbolic, numeric, t_b)
+
+    return x, dx
+
+
+def solve_with_numeric_f64_value_and_jvp(
+    arg_values: tuple[Array, Array, Array],
+    arg_tangents: tuple[Any, Any, Any],
+) -> tuple[Array, Array]:
+    return solve_with_numeric_value_and_jvp(
+        solve_with_numeric_f64, arg_values, arg_tangents
+    )
+
+
+ad.primitive_jvps[solve_with_numeric_f64] = solve_with_numeric_f64_value_and_jvp
+
+
+def solve_with_numeric_c128_value_and_jvp(
+    arg_values: tuple[Array, Array, Array],
+    arg_tangents: tuple[Any, Any, Any],
+) -> tuple[Array, Array]:
+    return solve_with_numeric_value_and_jvp(
+        solve_with_numeric_c128, arg_values, arg_tangents
+    )
+
+
+ad.primitive_jvps[solve_with_numeric_c128] = solve_with_numeric_c128_value_and_jvp
+
+
+def solve_with_numeric_transpose(
+    solve_prim: jax.extend.core.Primitive,
+    ct: Array,
+    symbolic: Array,
+    numeric: Array,
+    b: Array,
+) -> tuple[None, None, Array]:
+    """Compute the transpose of solve_with_numeric.
+
+    Uses the new tsolve primitives to efficiently solve A^T x_bar = b_bar
+    using the existing numeric factorization handle.
+    """
+    tsolve_prim = (
+        tsolve_with_numeric_f64
+        if solve_prim is solve_with_numeric_f64
+        else tsolve_with_numeric_c128
+    )
+
+    if ad.is_undefined_primal(b):
+        b_bar = tsolve_prim.bind(symbolic, numeric, ct)
+        # return None for symbolic and numeric handles, since they don't take gradients
+        return None, None, b_bar
+
+    msg = "No undefined primals in transpose."
+    raise ValueError(msg)
+
+
+def solve_with_numeric_f64_transpose(ct, symbolic, numeric, b):
+    return solve_with_numeric_transpose(
+        solve_with_numeric_f64, ct, symbolic, numeric, b
+    )
+
+
+ad.primitive_transposes[solve_with_numeric_f64] = solve_with_numeric_f64_transpose
+
+
+def solve_with_numeric_c128_transpose(ct, symbolic, numeric, b):
+    return solve_with_numeric_transpose(
+        solve_with_numeric_c128, ct, symbolic, numeric, b
+    )
+
+
+ad.primitive_transposes[solve_with_numeric_c128] = solve_with_numeric_c128_transpose

--- a/klujax.py
+++ b/klujax.py
@@ -12,9 +12,12 @@ __all__ = [
     "free_numeric",
     "free_symbolic",
     "refactor",
+    "refactor_and_solve",
     "solve",
     "solve_with_numeric",
     "solve_with_symbol",
+    "tsolve_with_numeric",
+    "tsolve_with_symbol",
 ]
 
 # Imports =============================================================================
@@ -391,6 +394,46 @@ def solve_with_symbol(
 
 
 @jax.jit
+def _tsolve_with_symbol_jit(Ai: Array, Aj: Array, Ax: Array, b: Array, sym_h: Array) -> Array:
+    Ai, Aj, Ax, b, out_shape = validate_numeric_solve(Ai, Aj, Ax, b)
+
+    is_complex = any(x.dtype in COMPLEX_DTYPES for x in (Ax, b))
+    prim = tsolve_with_symbol_c128 if is_complex else tsolve_with_symbol_f64
+
+    x = prim.bind(
+        Ai, Aj,
+        Ax.astype(jnp.complex128 if is_complex else jnp.float64),
+        b.astype(jnp.complex128 if is_complex else jnp.float64),
+        sym_h.astype(jnp.uint64)
+    )
+
+    return x.reshape(*out_shape)
+
+def tsolve_with_symbol(Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Union[KLUHandleManager, Array]) -> Array:
+    """Solve A^T x=b (transpose solve) using a pre-computed symbolic analysis.
+
+    Factors A numerically, then solves the transposed system using klu_tsolve.
+    The symbolic handle describes the sparsity pattern of A (not A^T), and is
+    reused as-is — KLU's triangular transpose solver handles the direction internally.
+
+    For complex matrices, this solves A^T x = b (plain transpose, not conjugate).
+    Use the conjugate transpose if you need A^H x = b.
+
+    Args:
+        Ai: [n_nz; int32]: the row indices of the sparse matrix A
+        Aj: [n_nz; int32]: the column indices of the sparse matrix A
+        Ax: [n_lhs? x n_nz; float64|complex128]: the values of the sparse matrix A
+        b:  [n_lhs? x n_col x n_rhs?; float64|complex128]: the target vector
+        symbolic: [KLUHandleManager|Array]: the symbolic analysis object or handle
+
+    Returns:
+        x: the result (x≈(A^T)^-1 b)
+
+    """
+    handle = getattr(symbolic, "handle", symbolic)
+    return _tsolve_with_symbol_jit(Ai, Aj, Ax, b, handle)
+
+@jax.jit
 def _factor_jit(Ai: Array, Aj: Array, Ax: Array, sym_h: Array) -> Array:
     dummy_b = jnp.zeros((1,), dtype=Ax.dtype)
     Ai, Aj, Ax, _, _ = validate_args(Ai, Aj, Ax, dummy_b)
@@ -495,6 +538,92 @@ def solve_with_numeric(
         free_numeric(numeric, dependency=result)
     return result
 
+@jax.jit
+def _tsolve_with_numeric_jit(num_h: Array, b: Array, sym_h: Array) -> Array:
+    prim = tsolve_with_numeric_c128 if b.dtype in COMPLEX_DTYPES else tsolve_with_numeric_f64
+    return prim.bind(sym_h.astype(jnp.uint64), num_h.astype(jnp.uint64), b)
+
+def tsolve_with_numeric(numeric: Union[KLUHandleManager, Array], b: Array, symbolic: Union[KLUHandleManager, Array]) -> Array:
+    """Solve A^T x=b (transpose solve) using a pre-computed numeric factorization.
+
+    Uses klu_tsolve internally. The numeric factorization must have been computed
+    for A (not A^T); KLU handles the transposition during the triangular solve.
+
+    For complex matrices, this solves A^T x = b (plain transpose, not conjugate).
+
+    Args:
+        numeric: [KLUHandleManager|Array]: the numeric factorization object or handle
+        b:  [n_lhs? x n_col x n_rhs?; float64|complex128]: the target vector
+        symbolic: [KLUHandleManager|Array]: the symbolic analysis object or handle
+
+    Returns:
+        x: the result (x≈(A^T)^-1 b)
+
+    """
+    num_h = getattr(numeric, "handle", numeric)
+    sym_h = getattr(symbolic, "handle", symbolic)
+    result = _tsolve_with_numeric_jit(num_h, b, sym_h)
+
+    if isinstance(num_h, jax.core.Tracer) and isinstance(numeric, KLUHandleManager):
+        free_numeric(numeric, dependency=result)
+    return result
+
+@jax.jit
+def _refactor_and_solve_jit(Ai: Array, Aj: Array, Ax: Array, b: Array, sym_h: Array, num_h: Array) -> Tuple[Array, Array]:
+    # Use validate_numeric_solve to standardize shapes and capture the expected out_shape
+    Ai, Aj, Ax, b, out_shape = validate_numeric_solve(Ai, Aj, Ax, b)
+    
+    is_complex = any(x.dtype in COMPLEX_DTYPES for x in (Ax, b))
+    prim = refactor_and_solve_c128 if is_complex else refactor_and_solve_f64
+    
+    x, out_num = prim.bind(
+        Ai, Aj,
+        Ax.astype(jnp.complex128 if is_complex else jnp.float64),
+        b.astype(jnp.complex128 if is_complex else jnp.float64),
+        sym_h.astype(jnp.uint64),
+        num_h.astype(jnp.uint64),
+    )
+    
+    # Reshape x back to the original dimensions of b
+    return x.reshape(*out_shape), out_num
+
+def refactor_and_solve(
+    Ai: Array,
+    Aj: Array,
+    Ax: Array,
+    b: Array,
+    numeric: Union[KLUHandleManager, Array],
+    symbolic: Union[KLUHandleManager, Array],
+) -> Tuple[Array, KLUHandleManager]:
+    """Fused in-place refactorization followed by triangular solve.
+
+    Equivalent to calling refactor() then solve_with_numeric(), but executes as a
+    single C++ kernel call. This avoids allocating the COO→CSC work buffer twice
+    and saves a JAX dispatch round-trip, which matters in tight iteration loops.
+
+    The numeric factorization is modified in-place (same behaviour as refactor()).
+    The returned KLUHandleManager wraps the same underlying pointer as the input
+    numeric handle with owner=False — the original owner is still responsible for
+    calling free_numeric.
+
+    Args:
+        Ai: [n_nz; int32]: the row indices of the sparse matrix A
+        Aj: [n_nz; int32]: the column indices of the sparse matrix A
+        Ax: [n_lhs? x n_nz; float64|complex128]: the values of the sparse matrix A
+        b:  [n_lhs? x n_col x n_rhs?; float64|complex128]: the right-hand side
+        numeric: [KLUHandleManager|Array]: existing numeric factorization (modified in-place)
+        symbolic: [KLUHandleManager|Array]: the symbolic analysis object or handle
+
+    Returns:
+        (x, numeric): solution array and the updated numeric handle
+                      (same pointer as input, owner=False, for XLA dep tracking)
+
+    """
+    num_h = getattr(numeric, "handle", numeric)
+    sym_h = getattr(symbolic, "handle", symbolic)
+    x, raw_numeric = _refactor_and_solve_jit(Ai, Aj, Ax, b, sym_h, num_h)
+    return x, KLUHandleManager(raw_numeric, free_numeric, owner=False)
+
 
 # Primitives ==========================================================================
 
@@ -505,14 +634,22 @@ solve_c128 = jax.extend.core.Primitive("solve_c128")
 analyze_p = jax.extend.core.Primitive("analyze")
 solve_with_symbol_f64 = jax.extend.core.Primitive("solve_with_symbol_f64")
 solve_with_symbol_c128 = jax.extend.core.Primitive("solve_with_symbol_c128")
+tsolve_with_symbol_f64 = jax.extend.core.Primitive("tsolve_with_symbol_f64")
+tsolve_with_symbol_c128 = jax.extend.core.Primitive("tsolve_with_symbol_c128")
 free_symbolic_p = jax.extend.core.Primitive("free_symbolic")
 factor_f64 = jax.extend.core.Primitive("factor_f64")
 factor_c128 = jax.extend.core.Primitive("factor_c128")
 solve_with_numeric_f64 = jax.extend.core.Primitive("solve_with_numeric_f64")
 solve_with_numeric_c128 = jax.extend.core.Primitive("solve_with_numeric_c128")
+tsolve_with_numeric_f64 = jax.extend.core.Primitive("tsolve_with_numeric_f64")
+tsolve_with_numeric_c128 = jax.extend.core.Primitive("tsolve_with_numeric_c128")
 free_numeric_p = jax.extend.core.Primitive("free_numeric")
 refactor_f64 = jax.extend.core.Primitive("refactor_f64")
 refactor_c128 = jax.extend.core.Primitive("refactor_c128")
+refactor_and_solve_f64 = jax.extend.core.Primitive("refactor_and_solve_f64")
+refactor_and_solve_c128 = jax.extend.core.Primitive("refactor_and_solve_c128")
+refactor_and_solve_f64.multiple_results = True
+refactor_and_solve_c128.multiple_results = True
 
 # Implementations =====================================================================
 
@@ -549,6 +686,16 @@ def solve_with_symbol_c128_impl(
     Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Array
 ) -> Array:
     return general_impl("solve_with_symbol_c128", Ai, Aj, Ax, b, symbolic)
+
+
+@tsolve_with_symbol_f64.def_impl
+def tsolve_with_symbol_f64_impl(Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Array) -> Array:
+    return general_impl("tsolve_with_symbol_f64", Ai, Aj, Ax, b, symbolic)
+
+
+@tsolve_with_symbol_c128.def_impl
+def tsolve_with_symbol_c128_impl(Ai: Array, Aj: Array, Ax: Array, b: Array, symbolic: Array) -> Array:
+    return general_impl("tsolve_with_symbol_c128", Ai, Aj, Ax, b, symbolic)
 
 
 @analyze_p.def_impl
@@ -598,6 +745,34 @@ def solve_with_numeric_c128_impl(symbolic, numeric, b):
         "solve_with_numeric_c128", jax.ShapeDtypeStruct(b.shape, b.dtype)
     )
     return call(symbolic, numeric, b)
+
+@tsolve_with_numeric_f64.def_impl
+def tsolve_with_numeric_f64_impl(symbolic, numeric, b):
+    call = jax.ffi.ffi_call("tsolve_with_numeric_f64", jax.ShapeDtypeStruct(b.shape, b.dtype))
+    return call(symbolic, numeric, b)
+
+@tsolve_with_numeric_c128.def_impl
+def tsolve_with_numeric_c128_impl(symbolic, numeric, b):
+    call = jax.ffi.ffi_call("tsolve_with_numeric_c128", jax.ShapeDtypeStruct(b.shape, b.dtype))
+    return call(symbolic, numeric, b)
+
+@refactor_and_solve_f64.def_impl
+def refactor_and_solve_f64_impl(Ai, Aj, Ax, b, symbolic, numeric):
+    n_lhs = Ax.shape[0]
+    call = jax.ffi.ffi_call(
+        "refactor_and_solve_f64",
+        (jax.ShapeDtypeStruct(b.shape, b.dtype), jax.ShapeDtypeStruct((n_lhs,), jnp.uint64)),
+    )
+    return call(Ai, Aj, Ax, b, symbolic, numeric)
+
+@refactor_and_solve_c128.def_impl
+def refactor_and_solve_c128_impl(Ai, Aj, Ax, b, symbolic, numeric):
+    n_lhs = Ax.shape[0]
+    call = jax.ffi.ffi_call(
+        "refactor_and_solve_c128",
+        (jax.ShapeDtypeStruct(b.shape, b.dtype), jax.ShapeDtypeStruct((n_lhs,), jnp.uint64)),
+    )
+    return call(Ai, Aj, Ax, b, symbolic, numeric)
 
 
 def general_impl(
@@ -683,6 +858,24 @@ solve_with_symbol_c128_low = mlir.lower_fun(
 mlir.register_lowering(solve_with_symbol_c128, solve_with_symbol_c128_low)
 
 jax.ffi.register_ffi_target(
+    "tsolve_with_symbol_f64",
+    klujax_cpp.tsolve_with_symbol_f64(),
+    platform="cpu",
+)
+
+tsolve_with_symbol_f64_low = mlir.lower_fun(tsolve_with_symbol_f64_impl, multiple_results=False)
+mlir.register_lowering(tsolve_with_symbol_f64, tsolve_with_symbol_f64_low)
+
+jax.ffi.register_ffi_target(
+    "tsolve_with_symbol_c128",
+    klujax_cpp.tsolve_with_symbol_c128(),
+    platform="cpu",
+)
+
+tsolve_with_symbol_c128_low = mlir.lower_fun(tsolve_with_symbol_c128_impl, multiple_results=False)
+mlir.register_lowering(tsolve_with_symbol_c128, tsolve_with_symbol_c128_low)
+
+jax.ffi.register_ffi_target(
     "free_symbolic",
     klujax_cpp.free_symbolic(),
     platform="cpu",
@@ -744,6 +937,22 @@ solve_with_numeric_c128_low = mlir.lower_fun(
 )
 mlir.register_lowering(solve_with_numeric_c128, solve_with_numeric_c128_low)
 
+jax.ffi.register_ffi_target("tsolve_with_numeric_f64", klujax_cpp.tsolve_with_numeric_f64(), platform="cpu")
+tsolve_with_numeric_f64_low = mlir.lower_fun(tsolve_with_numeric_f64_impl, multiple_results=False)
+mlir.register_lowering(tsolve_with_numeric_f64, tsolve_with_numeric_f64_low)
+
+jax.ffi.register_ffi_target("tsolve_with_numeric_c128", klujax_cpp.tsolve_with_numeric_c128(), platform="cpu")
+tsolve_with_numeric_c128_low = mlir.lower_fun(tsolve_with_numeric_c128_impl, multiple_results=False)
+mlir.register_lowering(tsolve_with_numeric_c128, tsolve_with_numeric_c128_low)
+
+jax.ffi.register_ffi_target("refactor_and_solve_f64", klujax_cpp.refactor_and_solve_f64(), platform="cpu")
+refactor_and_solve_f64_low = mlir.lower_fun(refactor_and_solve_f64_impl, multiple_results=True)
+mlir.register_lowering(refactor_and_solve_f64, refactor_and_solve_f64_low)
+
+jax.ffi.register_ffi_target("refactor_and_solve_c128", klujax_cpp.refactor_and_solve_c128(), platform="cpu")
+refactor_and_solve_c128_low = mlir.lower_fun(refactor_and_solve_c128_impl, multiple_results=True)
+mlir.register_lowering(refactor_and_solve_c128, refactor_and_solve_c128_low)
+
 free_numeric_low = mlir.lower_fun(free_numeric_impl, multiple_results=False)
 mlir.register_lowering(free_numeric_p, free_numeric_low)
 
@@ -789,9 +998,17 @@ def refactor_abstract_eval(Ai, Aj, Ax, symbolic, numeric):
 
 @solve_with_numeric_f64.def_abstract_eval
 @solve_with_numeric_c128.def_abstract_eval
+@tsolve_with_numeric_f64.def_abstract_eval
+@tsolve_with_numeric_c128.def_abstract_eval
 def solve_with_numeric_abstract_eval(symbolic, numeric, b):
     # Output has same shape as input b
     return ShapedArray(b.shape, b.dtype)
+
+@refactor_and_solve_f64.def_abstract_eval
+@refactor_and_solve_c128.def_abstract_eval
+def refactor_and_solve_abstract_eval(Ai, Aj, Ax, b, symbolic, numeric):
+    # Returns (x with same shape as b, out_numeric with same shape as numeric)
+    return ShapedArray(b.shape, b.dtype), ShapedArray(numeric.shape, jnp.uint64)
 
 
 # Forward Differentiation =============================================================
@@ -942,6 +1159,26 @@ def solve_with_symbol_c128_vmap(
 batching.primitive_batchers[solve_with_symbol_c128] = solve_with_symbol_c128_vmap
 
 
+def tsolve_with_symbol_f64_vmap(
+    vector_arg_values: tuple[Array, Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_with_symbol(tsolve_with_symbol_f64, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[tsolve_with_symbol_f64] = tsolve_with_symbol_f64_vmap
+
+
+def tsolve_with_symbol_c128_vmap(
+    vector_arg_values: tuple[Array, Array, Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_with_symbol(tsolve_with_symbol_c128, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[tsolve_with_symbol_c128] = tsolve_with_symbol_c128_vmap
+
+
 def solve_with_numeric_f64_vmap(
     vector_arg_values: tuple[Array, Array, Array],
     batch_axes: tuple[int | None, int | None, int | None],
@@ -964,6 +1201,26 @@ def solve_with_numeric_c128_vmap(
 
 
 batching.primitive_batchers[solve_with_numeric_c128] = solve_with_numeric_c128_vmap
+
+
+def tsolve_with_numeric_f64_vmap(
+    vector_arg_values: tuple[Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_with_numeric(tsolve_with_numeric_f64, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[tsolve_with_numeric_f64] = tsolve_with_numeric_f64_vmap
+
+
+def tsolve_with_numeric_c128_vmap(
+    vector_arg_values: tuple[Array, Array, Array],
+    batch_axes: tuple[int | None, int | None, int | None],
+) -> tuple[Array, int]:
+    return general_vmap_with_numeric(tsolve_with_numeric_c128, vector_arg_values, batch_axes)
+
+
+batching.primitive_batchers[tsolve_with_numeric_c128] = tsolve_with_numeric_c128_vmap
 
 
 def factor_f64_vmap(

--- a/tests.py
+++ b/tests.py
@@ -549,6 +549,129 @@ def test_solve_with_symbol_jvp():
     assert primals.shape == (2,)
     assert tangents.shape == (2,)
 
+@log_test_name
+@parametrize_dtypes
+def test_tsolve_with_symbol(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_1d(15, (n_col := 5), dtype=dtype)
+    symbolic = klujax.analyze(Ai, Aj, n_col)
+
+    x_sp = klujax.tsolve_with_symbol(Ai, Aj, Ax, b, symbolic)
+
+    # For tsolve, we compare against the transposed dense matrix A.T
+    A = jnp.zeros((n_col, n_col), dtype=dtype).at[Ai, Aj].add(Ax)
+    x = jsp.linalg.solve(A.T, b)
+    _log_and_test_equality(x, x_sp)
+
+    # Test JIT
+    x_sp_jit = jax.jit(klujax.tsolve_with_symbol)(Ai, Aj, Ax, b, symbolic)
+    _log_and_test_equality(x, x_sp_jit)
+
+    klujax.free_symbolic(symbolic)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_tsolve_with_symbol_batched(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_2d((n_lhs := 3), 15, (n_col := 5), dtype=dtype)
+    symbolic = klujax.analyze(Ai, Aj, n_col)
+
+    x_sp = klujax.tsolve_with_symbol(Ai, Aj, Ax, b, symbolic)
+
+    # Dense verification for batched transpose
+    op_dense = jax.vmap(jsp.linalg.solve, (0, 0), 0)
+    A = jnp.zeros((n_lhs, n_col, n_col), dtype=dtype).at[:, Ai, Aj].add(Ax)
+    A_T = jnp.swapaxes(A, -1, -2)
+    x = op_dense(A_T, b)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_symbolic(symbolic)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_tsolve_with_numeric(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_1d(15, (n_col := 5), dtype=dtype)
+    symbolic = klujax.analyze(Ai, Aj, n_col)
+    numeric = klujax.factor(Ai, Aj, Ax, symbolic)
+
+    x_sp = klujax.tsolve_with_numeric(numeric, b, symbolic)
+
+    A = jnp.zeros((n_col, n_col), dtype=dtype).at[Ai, Aj].add(Ax)
+    x = jsp.linalg.solve(A.T, b)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_numeric(numeric)
+    klujax.free_symbolic(symbolic)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_tsolve_with_numeric_batched(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_2d((n_lhs := 3), 15, (n_col := 5), dtype=dtype)
+    symbolic = klujax.analyze(Ai, Aj, n_col)
+    numeric = klujax.factor(Ai, Aj, Ax, symbolic)
+
+    x_sp = klujax.tsolve_with_numeric(numeric, b, symbolic)
+
+    # Dense verification for batched transpose
+    op_dense = jax.vmap(jsp.linalg.solve, (0, 0), 0)
+    A = jnp.zeros((n_lhs, n_col, n_col), dtype=dtype).at[:, Ai, Aj].add(Ax)
+    A_T = jnp.swapaxes(A, -1, -2)
+    x = op_dense(A_T, b)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_numeric(numeric)
+    klujax.free_symbolic(symbolic)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_refactor_and_solve(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_1d(15, (n_col := 5), dtype=dtype)
+    Ax2 = _make_ax2(Ai, Aj, Ax, dtype=dtype)
+    b2 = jax.random.normal(jax.random.PRNGKey(43), b.shape, dtype=dtype)
+
+    sym = klujax.analyze(Ai, Aj, n_col)
+    num = klujax.factor(Ai, Aj, Ax, sym)
+
+    # Verifying specific API order: Ai, Aj, Ax, b, numeric, symbolic
+    x_sp, num2 = klujax.refactor_and_solve(Ai, Aj, Ax2, b2, num, sym)
+    
+    assert isinstance(num2, klujax.KLUHandleManager)
+    assert num2._owner is False
+
+    A2 = jnp.zeros((n_col, n_col), dtype=dtype).at[Ai, Aj].add(Ax2)
+    x = jsp.linalg.solve(A2, b2)
+    _log_and_test_equality(x, x_sp)
+
+    # Original handle must be manually freed because num2 is owner=False
+    klujax.free_numeric(num)
+    klujax.free_symbolic(sym)
+
+
+@log_test_name
+@parametrize_dtypes
+def test_refactor_and_solve_batched(dtype):
+    Ai, Aj, Ax, b = _get_rand_arrs_2d((n_lhs := 3), 15, (n_col := 5), dtype=dtype)
+    Ax2 = _make_ax2(Ai, Aj, Ax, dtype=dtype)
+    b2 = jax.random.normal(jax.random.PRNGKey(43), b.shape, dtype=dtype)
+
+    sym = klujax.analyze(Ai, Aj, n_col)
+    num = klujax.factor(Ai, Aj, Ax, sym)
+
+    # Verifying specific API order: Ai, Aj, Ax, b, numeric, symbolic
+    x_sp, num2 = klujax.refactor_and_solve(Ai, Aj, Ax2, b2, num, sym)
+    
+    assert isinstance(num2, klujax.KLUHandleManager)
+    assert num2._owner is False
+
+    op_dense = jax.vmap(jsp.linalg.solve, (0, 0), 0)
+    A2 = jnp.zeros((n_lhs, n_col, n_col), dtype=dtype).at[:, Ai, Aj].add(Ax2)
+    x = op_dense(A2, b2)
+    _log_and_test_equality(x, x_sp)
+
+    klujax.free_numeric(num)
+    klujax.free_symbolic(sym)
 
 # KLUHandleManager testing
 

--- a/tests.py
+++ b/tests.py
@@ -549,6 +549,7 @@ def test_solve_with_symbol_jvp():
     assert primals.shape == (2,)
     assert tangents.shape == (2,)
 
+
 @log_test_name
 @parametrize_dtypes
 def test_tsolve_with_symbol(dtype):
@@ -636,7 +637,7 @@ def test_refactor_and_solve(dtype):
 
     # Verifying specific API order: Ai, Aj, Ax, b, numeric, symbolic
     x_sp, num2 = klujax.refactor_and_solve(Ai, Aj, Ax2, b2, num, sym)
-    
+
     assert isinstance(num2, klujax.KLUHandleManager)
     assert num2._owner is False
 
@@ -661,7 +662,7 @@ def test_refactor_and_solve_batched(dtype):
 
     # Verifying specific API order: Ai, Aj, Ax, b, numeric, symbolic
     x_sp, num2 = klujax.refactor_and_solve(Ai, Aj, Ax2, b2, num, sym)
-    
+
     assert isinstance(num2, klujax.KLUHandleManager)
     assert num2._owner is False
 
@@ -672,6 +673,7 @@ def test_refactor_and_solve_batched(dtype):
 
     klujax.free_numeric(num)
     klujax.free_symbolic(sym)
+
 
 # KLUHandleManager testing
 


### PR DESCRIPTION
* Adds `refactor_and_solve` which refactors the matrix in place (using the existing numeric handle) and solves immediately. Having this method eliminates another FFI pass for each Newton step during the non-linear solve.

* Added `tsolve_with_symbol` and `tsolve_with_numeric ` so as to speed up back-propagation. Without them, a new symbolic handle would have to be created when the transpose is calculated (as the sparsity pattern changes) during back propagation slowing things down. These are already present in the KLU library.

I want to test these in `circulax` more thoroughly before finalising the PR