### PR TITLE
Fixes around memory management in split-solve operations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build-wheels:
@@ -26,27 +27,44 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'aarch64'
+        if: (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) && matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'aarch64'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
       - name: Checkout Repository
-        if: startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
         uses: actions/checkout@v4
       - name: Install just
-        if: startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
         uses: extractions/setup-just@v2
       - name: Clone Suitesparse
-        if: startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
         run: just suitesparse
       - name: Clone XLA
-        if: startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
         run: just xla
       - name: Clone Pybind11
-        if: startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
         run: just pybind11
+      - name: Inject local version (manual runs)
+        if: github.event_name == 'workflow_dispatch'
+        shell: python
+        run: |
+          import os, re, pathlib
+          sha = os.environ["GITHUB_SHA"][:7]
+          run = os.environ["GITHUB_RUN_NUMBER"]
+          p = pathlib.Path("pyproject.toml")
+          text = p.read_text()
+          text = re.sub(
+              r'(?m)^version = "([^"]+)"',
+              lambda m: f'version = "{m.group(1)}+gha{run}.{sha}"',
+              text,
+              count=1,
+          )
+          p.write_text(text)
+          print(f"Patched version with local segment +gha{run}.{sha}")
       - name: Build Wheels
-        if: startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
         uses: pypa/cibuildwheel@v3.3.0
         env:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
@@ -55,12 +73,103 @@ jobs:
           # CIBW_BEFORE_TEST: "pip install pytest"
           # CIBW_TEST_COMMAND: "python {project}/.github/run_tests.py"
       - name: Upload Wheels
-        if: startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || matrix.os == 'ubuntu-latest' && matrix.cibw_archs == 'native'
         uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}
           path: ./wheelhouse/*.whl
           overwrite: true
+
+  prerelease:
+    name: Publish dev wheels
+    needs:
+      - build-wheels
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    steps:
+      - name: Set release tag
+        run: echo "RELEASE_TAG=dispatch-${{ github.ref_name }}-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - name: Generate uv source block
+        shell: python
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          import os, re, pathlib
+
+          base = f"https://github.com/{os.environ['REPO']}/releases/download/{os.environ['TAG']}"
+
+          def py_marker(t):
+              m = re.match(r"cp(\d)(\d+)$", t)
+              return f"python_version == '{m.group(1)}.{m.group(2)}'" if m else None
+
+          def platforms(tag):
+              res = []
+              for p in tag.split("."):
+                  if "linux" in p and p.endswith("x86_64"):
+                      res.append(("linux", "x86_64"))
+                  elif "linux" in p and p.endswith("aarch64"):
+                      res.append(("linux", "aarch64"))
+                  elif p.startswith("macosx") and p.endswith("x86_64"):
+                      res.append(("darwin", "x86_64"))
+                  elif p.startswith("macosx") and p.endswith("arm64"):
+                      res.append(("darwin", "arm64"))
+                  elif p.startswith("macosx") and p.endswith("universal2"):
+                      res += [("darwin", "x86_64"), ("darwin", "arm64")]
+                  elif p == "win_amd64":
+                      res.append(("win32", "AMD64"))
+                  elif p == "win_arm64":
+                      res.append(("win32", "ARM64"))
+              out = []
+              for x in res:
+                  if x not in out:
+                      out.append(x)
+              return out
+
+          entries = []
+          for whl in sorted(pathlib.Path("dist").glob("*.whl")):
+              pytag, abitag, plattag = whl.stem.rsplit("-", 3)[-3:]
+              pm = py_marker(pytag)
+              conds = [
+                  f"sys_platform == '{s}' and platform_machine == '{m}'"
+                  for s, m in platforms(plattag)
+              ]
+              plat = conds[0] if len(conds) == 1 else "(" + " or ".join(f"({c})" for c in conds) + ")"
+              marker = f"{pm} and {plat}" if pm else plat
+              entries.append((whl.name, marker))
+
+          lines = ["[tool.uv.sources]", "klujax = ["]
+          lines += [f'    {{ url = "{base}/{n}", marker = "{mk}" }},' for n, mk in entries]
+          lines.append("]")
+          toml = "\n".join(lines) + "\n"
+
+          pathlib.Path("uv-source.toml").write_text(toml)
+          print(toml)
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a") as f:
+                  f.write("## uv source for pyproject.toml\n\n```toml\n" + toml + "```\n")
+      - name: Publish pre-release with wheels
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: "Dev wheels (${{ env.RELEASE_TAG }})"
+          body: |
+            Wheels built from `${{ github.ref_name }}` at ${{ github.sha }}.
+            See `uv-source.toml` (attached) for a `[tool.uv.sources]` block
+            pinning each wheel by platform marker.
+          prerelease: true
+          files: |
+            dist/*.whl
+            uv-source.toml
 
   release:
     name: Create Release

--- a/klujax.py
+++ b/klujax.py
@@ -538,12 +538,7 @@ def solve_with_numeric(
     """
     num_h = getattr(numeric, "handle", numeric)
     sym_h = getattr(symbolic, "handle", symbolic)
-    result = _solve_with_numeric_jit(num_h, b, sym_h)
-
-    # Auto-cleanup if the handle was created inside a JIT block.
-    if isinstance(num_h, jax.core.Tracer) and isinstance(numeric, KLUHandleManager):
-        free_numeric(numeric, dependency=result)
-    return result
+    return _solve_with_numeric_jit(num_h, b, sym_h)
 
 
 @jax.jit
@@ -579,11 +574,7 @@ def tsolve_with_numeric(
     """
     num_h = getattr(numeric, "handle", numeric)
     sym_h = getattr(symbolic, "handle", symbolic)
-    result = _tsolve_with_numeric_jit(num_h, b, sym_h)
-
-    if isinstance(num_h, jax.core.Tracer) and isinstance(numeric, KLUHandleManager):
-        free_numeric(numeric, dependency=result)
-    return result
+    return _tsolve_with_numeric_jit(num_h, b, sym_h)
 
 
 @jax.jit

--- a/klujax.py
+++ b/klujax.py
@@ -191,20 +191,28 @@ class KLUHandleManager:
         self._owner = owner
         self._freed = False
 
-    def close(self) -> None:
-        """Release the C++ resource if this instance is the owner."""
+    def close(self) -> bool:
+        """Release the C++ resource if this instance is the owner.
+
+        Returns a boolean indicating if the resource has been freed.
+        """
         # Safety check: If the interpreter is shutting down, 'jax' might be None.
         # If so, we can simply return, as the OS will reclaim the memory momentarily.
         if jax is None:
-            return
+            return True
 
-        if self._freed or isinstance(self.handle, jax.core.Tracer):
-            return
+        if self._freed:
+            return True
+
+        if isinstance(self.handle, jax.core.Tracer):
+            return False
 
         if self._owner and self.free_callable:
             with contextlib.suppress(Exception):
                 self.free_callable(self.handle)
+
         self._freed = True
+        return True
 
     def __enter__(self) -> Self:
         return self
@@ -249,8 +257,9 @@ def free_symbolic(symbolic: KLUHandleManager | Array, dependency: Any = None) ->
 
     """
     if isinstance(symbolic, KLUHandleManager):
-        symbolic.close()
-        return jnp.array(0, dtype=jnp.int32)
+        freed = symbolic.close()
+        if freed:
+            return jnp.array(0, dtype=jnp.int32)
 
     handle = getattr(symbolic, "handle", symbolic)
     if isinstance(handle, jax.core.Tracer) and dependency is not None:
@@ -276,8 +285,9 @@ def free_numeric(numeric: KLUHandleManager | Array, dependency: Any = None) -> A
 
     """
     if isinstance(numeric, KLUHandleManager):
-        numeric.close()
-        return jnp.array(0, dtype=jnp.int32)
+        freed = numeric.close()
+        if freed:
+            return jnp.array(0, dtype=jnp.int32)
 
     handle = getattr(numeric, "handle", numeric)
     if isinstance(handle, jax.core.Tracer) and dependency is not None:

--- a/klujax.py
+++ b/klujax.py
@@ -1649,6 +1649,37 @@ def general_vmap_refactor(
     raise ValueError(msg)
 
 
+def free_numeric_p_vmap(
+    vector_arg_values: tuple[Array],
+    batch_axes: tuple[int | None],
+) -> tuple[Array, int | None]:
+    return (
+        jax.vmap(
+            jax.custom_batching.sequential_vmap(free_numeric_p.bind), in_axes=batch_axes
+        )(*vector_arg_values),
+        batch_axes[0],
+    )
+
+
+batching.primitive_batchers[free_numeric_p] = free_numeric_p_vmap
+
+
+def free_symbolic_p_vmap(
+    vector_arg_values: tuple[Array],
+    batch_axes: tuple[int | None],
+) -> tuple[Array, int | None]:
+    return (
+        jax.vmap(
+            jax.custom_batching.sequential_vmap(free_symbolic_p.bind),
+            in_axes=batch_axes,
+        )(*vector_arg_values),
+        batch_axes[0],
+    )
+
+
+batching.primitive_batchers[free_symbolic_p] = free_symbolic_p_vmap
+
+
 # Transposition =======================================================================
 
 

--- a/klujax.py
+++ b/klujax.py
@@ -263,13 +263,7 @@ def free_symbolic(symbolic: KLUHandleManager | Array, dependency: Any = None) ->
 
     handle = getattr(symbolic, "handle", symbolic)
     if isinstance(handle, jax.core.Tracer) and dependency is not None:
-        token = jax.tree_util.tree_leaves(dependency)[0]
-        return lax.cond(
-            jnp.array(True),  # noqa: FBT003
-            lambda ops: free_symbolic_p.bind(ops[0]),
-            lambda _: jnp.array(0, dtype=jnp.int32),
-            operand=(handle, token),
-        )
+        handle, _ = lax.optimization_barrier((handle, dependency))
     return free_symbolic_p.bind(handle)
 
 
@@ -291,13 +285,7 @@ def free_numeric(numeric: KLUHandleManager | Array, dependency: Any = None) -> A
 
     handle = getattr(numeric, "handle", numeric)
     if isinstance(handle, jax.core.Tracer) and dependency is not None:
-        token = jax.tree_util.tree_leaves(dependency)[0]
-        return lax.cond(
-            jnp.array(True),  # noqa: FBT003
-            lambda ops: free_numeric_p.bind(ops[0]),
-            lambda _: jnp.array(0, dtype=jnp.int32),
-            operand=(handle, token),
-        )
+        handle, _ = lax.optimization_barrier((handle, dependency))
     return free_numeric_p.bind(handle)
 
 

--- a/klujax.py
+++ b/klujax.py
@@ -1043,8 +1043,8 @@ def analyze_abstract_eval(Ai: Array, Aj: Array, n_col: Array) -> ShapedArray:
 
 
 @free_symbolic_p.def_abstract_eval
-def free_symbolic_abstract_eval(symbolic: Array) -> None:
-    return None
+def free_symbolic_abstract_eval(symbolic: Array) -> ShapedArray:
+    return ShapedArray((), jnp.int32)
 
 
 @factor_f64.def_abstract_eval

--- a/klujax.py
+++ b/klujax.py
@@ -747,14 +747,22 @@ def factor_c128_impl(Ai, Aj, Ax, symbolic):
 @refactor_f64.def_impl
 def refactor_f64_impl(Ai, Aj, Ax, symbolic, numeric):
     n_lhs = Ax.shape[0]
-    call = jax.ffi.ffi_call("refactor_f64", jax.ShapeDtypeStruct((n_lhs,), jnp.uint64))
+    call = jax.ffi.ffi_call(
+        "refactor_f64",
+        jax.ShapeDtypeStruct((n_lhs,), jnp.uint64),
+        has_side_effect=True,
+    )
     return call(Ai, Aj, Ax, symbolic, numeric)
 
 
 @refactor_c128.def_impl
 def refactor_c128_impl(Ai, Aj, Ax, symbolic, numeric):
     n_lhs = Ax.shape[0]
-    call = jax.ffi.ffi_call("refactor_c128", jax.ShapeDtypeStruct((n_lhs,), jnp.uint64))
+    call = jax.ffi.ffi_call(
+        "refactor_c128",
+        jax.ShapeDtypeStruct((n_lhs,), jnp.uint64),
+        has_side_effect=True,
+    )
     return call(Ai, Aj, Ax, symbolic, numeric)
 
 
@@ -935,13 +943,17 @@ jax.ffi.register_ffi_target(
 
 @free_numeric_p.def_impl
 def free_numeric_impl(numeric):
-    call = jax.ffi.ffi_call("free_numeric", jax.ShapeDtypeStruct((), jnp.int32))
+    call = jax.ffi.ffi_call(
+        "free_numeric", jax.ShapeDtypeStruct((), jnp.int32), has_side_effect=True
+    )
     return call(numeric)
 
 
 @free_symbolic_p.def_impl
 def free_symbolic_impl(symbolic):
-    call = jax.ffi.ffi_call("free_symbolic", jax.ShapeDtypeStruct((), jnp.int32))
+    call = jax.ffi.ffi_call(
+        "free_symbolic", jax.ShapeDtypeStruct((), jnp.int32), has_side_effect=True
+    )
     return call(symbolic)
 
 

--- a/klujax.py
+++ b/klujax.py
@@ -5,6 +5,7 @@
 __version__ = "0.5.0"
 __author__ = "Floris Laporte"
 __all__ = [
+    "KLUMemoryLeakWarning",
     "analyze",
     "coalesce",
     "dot",
@@ -25,6 +26,7 @@ __all__ = [
 import contextlib
 import os
 import sys
+import warnings
 from collections.abc import Callable
 from types import TracebackType
 from typing import Any, Self
@@ -177,6 +179,10 @@ def coalesce(
 # Split Solve pointer management =====================================================
 
 
+class KLUMemoryLeakWarning(UserWarning):
+    """Warn that a handle was likely garbage-collected without being freed."""
+
+
 class KLUHandleManager:
     """RAII wrapper for KLU handles. Handles are freed on __del__ or __exit__."""
 
@@ -228,6 +234,23 @@ class KLUHandleManager:
     def __del__(self) -> None:
         if hasattr(self, "close"):
             self.close()
+
+        # If an owning manager gets GC'd while still holding an unfreed handle,
+        # this is because it needed to be freed explicitly but this never
+        # happened. To inform the user of this, we raise a warning here.
+        if (
+            jax is not None
+            and getattr(self, "_owner", False)
+            and not getattr(self, "_freed", True)
+            and not isinstance(getattr(self, "handle", None), jax.core.Tracer)
+        ):
+            warnings.warn(
+                "An owning KLUHandleManager was garbage-collected without its "
+                "handle being freed. Free it explicitly via `free_symbolic` or "
+                "`free_numeric` to avoid a possible memory leak.",
+                KLUMemoryLeakWarning,
+                stacklevel=2,
+            )
 
 
 def _klu_flatten(obj: KLUHandleManager) -> tuple[tuple[()], tuple[Array, Callable]]:

--- a/tests.py
+++ b/tests.py
@@ -284,7 +284,9 @@ def test_solve_with_numeric_vmap_1d_b(dtype):
 
     def solve_one(Ax_i):
         num = klujax.factor(Ai, Aj, Ax_i, symbolic)
-        return klujax.solve_with_numeric(num, b, symbolic)
+        result = klujax.solve_with_numeric(num, b, symbolic)
+        klujax.free_numeric(num, dependency=result)
+        return result
 
     x_sp = jax.vmap(solve_one)(Ax_batch)
 


### PR DESCRIPTION
After observing some inconsistencies in the way handles for factorization objects are managed in combination with using JIT, I made an issue detailing these: #30. Since this repo doesn't seem super active, I decided to have a go at fixing these myself :)

This PR contains the following changes:
1. **Change `free_symbolic_abstract_eval` to align with return type**: this allows using `free_symbolic_p`.
2. **Add `has_side_effect=True` to FFI primitives that cannot be safely eliminated**: this makes sure that primitives which modify some existing memory buffer (free primtives and refactor) are not removed by XLA as a result of static analysis.
3. **Make sure handles created in JIT are freed properly**: when a `KLUHandleManager` holds a traced handle, this is not freed upon calling `close` (since it needs to be freed explicitly with a dependency). This change adds a check to the `free_` functions so that if `close` doesn't free the handle, it will still be freed explicitly.
4. **Simplify free-with-dependency logic**: this is just a small cleanup. To force the ordering of the free primitives after the solutions that make use of the managed handle, it is cleaner to use `jax.lax.optimization_barrier` instead.

I am curious to hear if you think these changes are good and correct, and if they could be merged upstream. I think there should be a version bump as well, but not sure what aligns with the project versioning scheme.